### PR TITLE
fix(chat): add localStorage save and clear functionality

### DIFF
--- a/Client/src/components/home/navBar/AiChatbot.jsx
+++ b/Client/src/components/home/navBar/AiChatbot.jsx
@@ -1,6 +1,13 @@
 import { useState, useRef, useEffect } from "react";
 import { toast } from "react-toastify";
-import { BotMessageSquare, X, ArrowUp, Loader, Spline, Trash2 } from "lucide-react";
+import {
+  BotMessageSquare,
+  X,
+  ArrowUp,
+  Loader,
+  Spline,
+  Trash2,
+} from "lucide-react";
 import { motion } from "framer-motion";
 import "react-toastify/dist/ReactToastify.css";
 
@@ -210,13 +217,6 @@ const Ai = () => {
             <h3 className="text-lg txt-dim font-semibold pl-8">Ask AI</h3>
             <div className="flex items-center gap-1">
               <button
-                onClick={clearChat}
-                className="hover:text-red-500 transition p-2 txt-dim"
-                title="Clear Chat"
-              >
-                <Trash2 />
-              </button>
-              <button
                 onClick={closeModal}
                 className="hover:txt transition p-2 txt-dim"
               >
@@ -260,6 +260,20 @@ const Ai = () => {
               ))
             )}
           </div>
+
+          {/* Clear Chat Button at Bottom (only if messages exist) */}
+          {messages.length > 0 && (
+            <div className="flex justify-end px-4 pb-2">
+              <button
+                onClick={clearChat}
+                className="text-sm text-red-400 hover:text-red-500 flex items-center gap-1 transition"
+                title="Clear Chat"
+              >
+                <Trash2 className="w-4 h-4" />
+                <span>Clear Chat</span>
+              </button>
+            </div>
+          )}
 
           {/* Input area */}
           <div


### PR DESCRIPTION
### Summary

- Chat messages are now saved to localStorage.
- A trash icon was added to clear the chat history.
- On clicking the icon, localStorage is also cleared along with the UI.

### Changes Made

- Updated chat logic to persist data via localStorage
- Added delete (🗑️) button to UI
- Attached event listener to clear both UI and storage

### Screenshots (if UI changed)

<img width="1911" height="965" alt="image" src="https://github.com/user-attachments/assets/a6b6f455-1be2-4548-8406-195238c1479e" />

<upload if applicable>

### Related Issues

Closes #157 (if there's a linked GitHub issue)

---

