### PR TITLE
added hi score storage for games

### DIFF
--- a/Client/src/components/games/SnakeGame.jsx
+++ b/Client/src/components/games/SnakeGame.jsx
@@ -1,10 +1,21 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import $ from "jquery";
 import "./snake.css";
 import { Link } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 
 const SnakeGame = () => {
+
+  const [hiScore,setHiScore] = useState(0);
+
+  // fetches the prev hi score on mount
+  useEffect(()=>{
+    const prevHiScore = localStorage.getItem("snakeHiScore");
+    if(prevHiScore){
+      setHiScore(parseInt(prevHiScore));
+    }
+  },[])
+
   useEffect(() => {
     Math.PI2 = 2 * Math.PI;
     if (!window.requestAnimationFrame) {
@@ -170,6 +181,12 @@ const SnakeGame = () => {
         /* Prevent photoshopping */
         ctx.font = "30px" + scoreFont;
         var rScore = Math.round(score);
+
+        // Update high score if beaten
+        if (rScore > hiScore) {
+          localStorage.setItem("snakeHiScore", rScore);
+          setHiScore(rScore);
+        }
         ctx.textBaseline = "middle";
         ctx.save();
         ctx.translate(w * 0.5, h * 0.5 + 15);
@@ -413,7 +430,10 @@ const SnakeGame = () => {
           </div>
         </div>
       </div>
-      <canvas id="c"></canvas>
+      <div className="text-white font-semibold text-xs ml-4 mb-3">
+          High Score: {hiScore}
+        </div>
+      <canvas className="ml-10" id="c"></canvas>
       <div className="notice-pause">
         Use space or down to pause and space or up to resume.
       </div>

--- a/Client/src/components/games/SpaceType.jsx
+++ b/Client/src/components/games/SpaceType.jsx
@@ -589,6 +589,7 @@ const SpaceType = () => {
   const [particles, setParticles] = useState([]);
   const shipRef = useRef(null);
   const [currentTarget, setCurrentTarget] = useState(null);
+  const [hiScore,setHiScore] = useState(0);
 
   // Sound effects
   const [playLaser] = useSound("./laser.mp3", { volume: 0.5 });
@@ -672,6 +673,29 @@ const SpaceType = () => {
       setEnemies((prev) => [...prev, newEnemy]);
     }
   }, [enemies.length, isPaused, gameOver, level]);
+
+  // get the previous highscore
+  useEffect(() => {
+    const prevScore = localStorage.getItem("spaceTypeHiScore");
+    if(prevScore){
+      setHiScore(parseInt(prevScore));
+    }
+  },[])
+
+  // when game ends highscore is saved.
+  useEffect(() => {
+  if (gameOver) {
+    playGameOver();
+    setHiScore((prevHighScore) => {
+      if (score > prevHighScore) {
+        localStorage.setItem("spaceTypeHiScore", score);
+        return score;
+      }
+      return prevHighScore;
+    });
+  }
+}, [gameOver]);
+
 
   useEffect(() => {
     const spawnInterval = setInterval(spawnEnemy, 2000 - level * 100);
@@ -791,6 +815,7 @@ const SpaceType = () => {
       {/* UI Header */}
       <div className="absolute top-0 left-0 right-0 p-4 flex justify-between items-center text-white">
         <div className="flex gap-4">
+          <div>HiScore: {hiScore}</div>
           <div>Score: {score}</div>
           <div>Level: {level}</div>
           <div>WPM: {wpm}</div>


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what this PR does. -->
Stores the high score in local storage. Implemented storage for Hungry Snake, Space typing, and Whac-A-Mole. Tic Tac Toe doesn’t have any type of score, just winners. The old typing game is probably going to be replaced by the new Space typing.

## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #75 

## Changes Made
<!-- List the changes made in this PR. -->
- [x] updated the logic on the games to fetch prev hi score on mount
- [x] updated the elements to show the high score 

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->
<img width="1470" height="956" alt="Screenshot 2025-08-03 at 10 37 26 AM" src="https://github.com/user-attachments/assets/1246e128-b80c-4322-8229-43d10cb1daa5" />
<img width="1470" height="956" alt="Screenshot 2025-08-03 at 10 45 23 AM" src="https://github.com/user-attachments/assets/07bd836f-5bdc-449c-90ab-eb1ce00c373c" />


## Checklist
- [x] I have performed a self-review of my code.
- [x] My changes are well-documented.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published.

## Additional Notes
<!-- Add any other relevant information or context. -->
@RishuKumarCodes pls review.
