### PR TITLE
Make the calendars upcoming events card scrollable

### DIFF
--- a/Client/src/components/home/calenderComponent/CalendarComponent.jsx
+++ b/Client/src/components/home/calenderComponent/CalendarComponent.jsx
@@ -37,17 +37,17 @@ function Calendar() {
   const fetchEvents = async () => {
     try {
       // Get authentication token from localStorage
-      const token = localStorage.getItem('token');
-      
+      const token = localStorage.getItem("token");
+
       if (!token) {
-        console.error('No authentication token found');
+        console.error("No authentication token found");
         return;
       }
 
       const response = await axios.get(`${backendUrl}/events`, {
         headers: {
-          'Authorization': `Bearer ${token}`
-        }
+          Authorization: `Bearer ${token}`,
+        },
       });
 
       if (response.data.success) {
@@ -61,7 +61,7 @@ function Calendar() {
         futureEvents.sort(
           (a, b) => new Date(a.date) - new Date(b.date) // Sort by date
         );
-        setUpcomingEvents(futureEvents.slice(0, 2)); // Limit to two events
+        setUpcomingEvents(futureEvents.slice(0, 10)); // Limit to ten events
       } else {
         console.error("Failed to fetch events:", response.data.error);
       }
@@ -69,7 +69,7 @@ function Calendar() {
       console.error("Error fetching events:", error.message);
       // Handle unauthorized access
       if (error.response?.status === 401) {
-        console.error('Unauthorized: Please log in again');
+        console.error("Unauthorized: Please log in again");
         // You might want to redirect to login page here
       }
     }
@@ -101,19 +101,20 @@ function Calendar() {
 
   const blankDays = Array(firstDayOfMonth).fill(null);
 
-  const formattedTime = localStorage.getItem("clock-format") === "24-hour"
-    ? (time.toLocaleTimeString("en-US", {
+  const formattedTime =
+    localStorage.getItem("clock-format") === "24-hour"
+      ? time.toLocaleTimeString("en-US", {
           hour: "2-digit",
           minute: "2-digit",
           second: "2-digit",
           hour12: false,
-        }))
-    : (time.toLocaleTimeString("en-US", {
+        })
+      : time.toLocaleTimeString("en-US", {
           hour: "2-digit",
           minute: "2-digit",
           second: "2-digit",
           hour12: true,
-        }));
+        });
 
   const [timePart, period] = formattedTime.split(" ");
 
@@ -159,10 +160,7 @@ function Calendar() {
           </div>
           <div className="grid grid-cols-7 gap-[0.4rem]">
             {"Su Mo Tu We Th Fr Sa".split(" ").map((day) => (
-              <div
-                key={day}
-                className="text-center text-xs font-md txt-dim"
-              >
+              <div key={day} className="text-center text-xs font-md txt-dim">
                 {day}
               </div>
             ))}
@@ -200,12 +198,10 @@ function Calendar() {
 
         {/* Upcoming Events Section with subtle animations */}
         <div className="p-6 rounded-3xl bg-ter flex-1 mt-6">
-          <h3 className="text-lg font-semibold txt mb-4">
-            Upcoming Events:
-          </h3>
+          <h3 className="text-lg font-semibold txt mb-4">Upcoming Events:</h3>
           {upcomingEvents.length > 0 ? (
             <motion.ul
-              className="txt space-y-6 pl-2"
+              className="txt space-y-6 pl-2 pr-3 overflow-x-scroll max-h-[120px]"
               initial="hidden"
               animate="visible"
               variants={{

--- a/Client/src/index.css
+++ b/Client/src/index.css
@@ -423,4 +423,8 @@ body {
   ::-webkit-scrollbar-thumb:hover {
     background: rgba(155, 154, 154, 0.6);
   }
+
+  ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
 }


### PR DESCRIPTION


## Description
<!-- A clear and concise description of what this PR does. -->
Add a scrollbar to the upcoming events card to allow more than two events to be displayed.

## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #224

## Changes Made
<!-- List the changes made in this PR. -->
index.css: 
- L427: Delete the white scrollbar corner.
CalendarComponent:
- Mostly automatic Prettier changes.
- L64: Limit to ten events instead of two.
- L204: Add overflow-x-scroll and a max-height to maintain the height of the events box. Add a right padding to give the scrollbar some space.

## Screenshots or GIFs (if applicable)
<img width="365" height="224" alt="image" src="https://github.com/user-attachments/assets/14656453-d97c-4207-9dc7-df3e0893bc0d" />

## Checklist
- [x ] I have performed a self-review of my code.
- [ x] My changes are well-documented.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ x] Any dependent changes have been merged and published.

## Additional Notes
<!-- Add any other relevant information or context. -->
