### PR TITLE
UI: Updated the '+' icon on Goals section

### DIFF
--- a/Client/src/components/home/goalsAndNotes/SetGoals.jsx
+++ b/Client/src/components/home/goalsAndNotes/SetGoals.jsx
@@ -98,7 +98,7 @@ const Setgoals = ({ onGoalCreated}) => {
               whileHover={{ scale: 1.05 }}
               animate={{ scale: 1, transition: { duration: 0 } }}
               onClick={handleCreate}
-              className={`add-goal-btn bg-ter ml-2 px-4 py-2 rounded font-semibold shadow focus:outline-none focus:ring-2 focus:ring-offset-2 transition-all border ${styles["add-goal-btn"]}`}
+              className={`add-goal-btn ml-2 font-bold shadow focus:outline-none focus:ring-2 focus:ring-offset-2 transition-all ${styles["add-goal-btn"]}`}
               aria-label="Add Goal"
               type="button"
             >

--- a/Client/src/components/home/goalsAndNotes/SetGoals.module.css
+++ b/Client/src/components/home/goalsAndNotes/SetGoals.module.css
@@ -1,7 +1,30 @@
+.add-goal-btn {
+  padding: 0.25rem 1rem;
+  border-radius: 999px;
+
+  /* Make button lighter than main background (not blue) */
+  background-color: color-mix(in srgb, var(--bg), white 20%);
+  /* Fallback: semi-white if color-mix unsupported */
+  background-color: rgba(255,255,255, 0.15);
+
+  color: var(--button-txt);
+  border: none;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s;
+}
+
+
 .add-goal-btn:hover,
 .add-goal-btn:focus {
-  background: var(--button-txt);  /* Swap colors on hover */
-  color: var(--button-bg);      /* Swap back to original */
-  border-color: var(--button-bg);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  background-color: color-mix(in srgb, var(--bg), white 95%); 
+  color: var(--button-txt);/* Slightly darker */
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.2);
+  transform: translateY(-1px);
+}
+
+/* Active */
+.add-goal-btn:active {
+  background-color: color-mix(in srgb, var(--bg), white 35%);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  transform: translateY(0);
 }


### PR DESCRIPTION
# Solves #295 
## Description
<!-- A clear and concise description of what this PR does. -->
This PR replaces the existing “+” icon in the Goals section with a clearly labeled Add button, improving clarity and reducing user confusion.
Additionally, the button now only appears when the input field contains text, making the UI cleaner and preventing unnecessary clicks.

## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #295 

## Changes Made
<!-- List the changes made in this PR. -->
- Removed the Plus icon usage for goal creation.
- Added a new Add button styled consistently with theme colors and hover effects.
- Implemented conditional rendering so the Add button only appears when title.trim() is not empty.
- Integrated Framer Motion animations for smooth hover/tap transitions.
- Applied CSS changes to swap background and text colors on hover for better interactivity feedback.
- Ensured styles are responsive and maintain consistency across all themes.

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->
The below is video which shows that add button is seen only when the input is not empty:

https://github.com/user-attachments/assets/d38f4d56-2893-4a5c-9fe2-63ae46f67eb3


The below are screenshots of the goal section in different themes:
<img width="468" height="331" alt="image" src="https://github.com/user-attachments/assets/bc809ad6-8d1a-4e61-8432-db5db43b4abd" />
<img width="462" height="312" alt="image" src="https://github.com/user-attachments/assets/0e6ba857-029d-4215-af4f-a9cc3c243d37" />
<img width="466" height="318" alt="image" src="https://github.com/user-attachments/assets/63b962f5-9ce5-4a1e-8251-4c052995ffa0" />
<img width="478" height="332" alt="image" src="https://github.com/user-attachments/assets/fb44f0c0-076c-4caa-ada4-1ce7c7474bfc" />


## Checklist
- [ ] I have performed a self-review of my code.
- [ ] My changes are well-documented.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published.

