### PR TITLE
add friends button in sidebar

### DIFF
--- a/Client/src/components/Sidebar.jsx
+++ b/Client/src/components/Sidebar.jsx
@@ -6,6 +6,7 @@ import {
   Radio,
   Settings,
   BadgeInfo,
+  Users
 } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { motion } from "framer-motion";
@@ -43,9 +44,8 @@ function Sidebar() {
           className="relative flex flex-col items-center justify-center pt-2.5 pb-1.5 group hover:bg-ter rounded-lg transition-colors"
         >
           <IconComponent
-            className={`w-6 h-6 transition-colors duration-300 ${
-              isActive ? "txt" : "!txt-disabled group-hover:txt"
-            }`}
+            className={`w-6 h-6 transition-colors duration-300 ${isActive ? "txt" : "!txt-disabled group-hover:txt"
+              }`}
           />
           <span className="text-xs txt-dim">{label}</span>
         </Link>
@@ -65,9 +65,8 @@ function Sidebar() {
             <img
               src="./Logo.svg"
               alt="Logo"
-              className={`w-full m-auto object-contain p-4 logo-filter ${
-                isHome ? "opacity-100" : "opacity-80"
-              }`}
+              className={`w-full m-auto object-contain p-4 logo-filter ${isHome ? "opacity-100" : "opacity-80"
+                }`}
             />
           </div>
         </Link>
@@ -100,6 +99,14 @@ function Sidebar() {
             isActive={location.pathname === "/games"}
             ref={(el) => (linkRefs.current["/games"] = el)}
           />
+          <SidebarLink
+            to="/friends"
+            IconComponent={Users}
+            label="Friends"
+            isActive={location.pathname === "/friends"}
+            ref={(el) => (linkRefs.current["/friends"] = el)}
+          />
+          
         </div>
         <hr className="border-sec my-5 mx-4" />
         <SidebarLink


### PR DESCRIPTION
Description

Added a Friends button to the sidebar that redirects users to the /friends page, using the Users icon from lucide-react.

Related Issue

Fixes # 308

Changes Made

 Imported Users icon from lucide-react.

 Added SidebarLink for /friends route in the sidebar.

 Ensured active state highlighting works with the animated indicator.

Sidebar with Friends Button:
<img width="1919" height="849" alt="image" src="https://github.com/user-attachments/assets/d0fd9966-7e9c-47f7-ac63-4e425aa64f15" />


Checklist
 I have performed a self-review of my code.
 My changes are well-documented.
 I have tested the Friends button and confirmed it navigates to /friends.
 No existing functionality is broken.