### PR TITLE
Solve Renders Cold Start problem #277

### DIFF
--- a/KEEP_ALIVE.md
+++ b/KEEP_ALIVE.md
@@ -1,0 +1,28 @@
+# Preventing Render Cold Starts
+
+## Background
+The Eduhaven backend is hosted on **Render Free Tier**, which automatically puts the instance to sleep after around **50 seconds** of inactivity.  
+When the instance wakes up (cold start), it causes **3–15 seconds delay** for the first user request.
+
+## Solution
+We use an external service — **[cron-job.org](https://cron-job.org/)** — to send a request to the backend every **1 minute**.  
+This keeps the backend active and eliminates most cold start delays.
+
+## Cron Job Details
+- **Service:** cron-job.org
+- **URL to ping:**  
+  `https://eduhaven-backend.onrender.com/`
+- **Frequency:** Every 1 minute
+- **Method:** GET
+- **Expected Response:** HTTP `200 OK`
+
+
+## How to Set Up Your Own Cron Job
+1. Go to [cron-job.org](https://cron-job.org/).
+2. Create a free account.
+3. Add a **New Cronjob**:
+   - Title: `Eduhaven Keep Alive`
+   - URL: `https://eduhaven-backend.onrender.com/`
+   - Schedule: Every 1 minute
+4. Save and activate.
+5. Check the **execution history** tab to confirm requests are successful.

--- a/README.md
+++ b/README.md
@@ -131,4 +131,16 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ---
 
+
+## Preventing Backend Cold Starts
+The backend is hosted on Render Free Tier and may go to sleep after short inactivity.  
+We have implemented a keep-alive solution using [cron-job.org](https://cron-job.org/) to ping the backend every 1 minute:
+
+- URL: https://eduhaven-backend.onrender.com/
+- Interval: Every 1 minute
+- Purpose: Prevents backend cold starts for faster response times.
+
+For full details, see [`KEEP_ALIVE.md`](KEEP_ALIVE.md).
+
+
 For any further queries, feel free to reach out on our whatsApp group. Let’s make learning fun and productive!


### PR DESCRIPTION
Problem

On Render’s free tier, the backend instance goes to sleep after ~50 seconds of inactivity.
When the next request arrives, it causes a cold start delay (several seconds), making the app feel slow for users.

Solution
I have set up an external cron job at [cron-job.org](https://cron-job.org/) that sends a request to the backend every 1 minute, preventing it from going idle.
Why cron-job.org is better than GitHub Actions

Advantages of cron-job.org:
✅ Can run every 1 minute (GitHub Actions minimum is 5 minutes)
✅ Works without adding any YAML or code to the repo
✅ Keeps running even if the repo is inactive
✅ Very quick to set up
✅ Has a free tier

GitHub Actions limitations:
❌ Cannot run faster than once every 5 minutes
❌ Requires adding .yml workflow files to the repo
❌ May pause or fail if the repo is inactive

Verification
Configured cron-job.org to ping:
https://eduhaven-backend.onrender.com


Interval: Every 1 minute
Checked logs — 200 OK responses confirm it’s working:

[16:25] 200 OK — 589 ms
[16:24] 200 OK — 624 ms
[16:23] 200 OK — 708 ms

Impact
Keeps the Render app responsive even after inactivity.
Removes user delays from cold starts.
Does not modify production code.

<img width="1909" height="861" alt="image" src="https://github.com/user-attachments/assets/e5012abe-8754-47ef-8586-6b9033fc916e" />


<img width="1919" height="862" alt="image" src="https://github.com/user-attachments/assets/db87c765-ece2-4824-ba11-9f88cb5daf66" />

<img width="1903" height="868" alt="image" src="https://github.com/user-attachments/assets/fdacd4a5-45cd-4b9d-86b2-b4ca5b5a5c6c" />
