### PR TITLE
fix the session Rooms filter

### DIFF
--- a/Client/src/components/session/OtherRooms.jsx
+++ b/Client/src/components/session/OtherRooms.jsx
@@ -43,7 +43,7 @@ function RoomCardSkeleton() {
   );
 }
 
-export default function OtherRoom({ otherRooms, isLoading = true }) {
+export default function OtherRoom({ otherRooms, isLoading = false }) {
   const [sessions, setSessions] = useState([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("All");
@@ -74,7 +74,7 @@ export default function OtherRoom({ otherRooms, isLoading = true }) {
     }
   };
 
-  const showSkeletons = isLoading && sessions.length === 0;
+  const showSkeletons = !isLoading && sessions.length === 0;
 
   return (
     <div>


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what this PR does. -->
This PR fix the `session Room filter`  not working issue.  

## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #339 

## Changes Made
<!-- List the changes made in this PR. -->
- [X] Updated isloading default value so that filter, chevrons, and search button become active
- [X] reversed isloading for the showskeletion to render correctly  without breaking when no session are present. 

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->

Here you can see the changes in attached video file. 
[Screencast_20250816_185505.webm](https://github.com/user-attachments/assets/555b7ee9-cd09-4573-98ae-99a45a08756c)

and when no session Rooms are present , it shows just skeltion with working filters .
[Screencast_20250816_134623.webm](https://github.com/user-attachments/assets/ed799ed1-8187-44ac-9d12-92fb71a7bcc7)






## Checklist
- [X] I have performed a self-review of my code.
- [X] My changes are well-documented.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published.

## Additional Notes
<!-- Add any other relevant information or context. -->
