### PR TITLE
[FIX]: #365 Swap the position of games and friends button 

### DIFF
--- a/Client/src/components/Sidebar.jsx
+++ b/Client/src/components/Sidebar.jsx
@@ -101,13 +101,13 @@ function Sidebar() {
             isActive={location.pathname === "/friends"}
             ref={(el) => (linkRefs.current["/friends"] = el)}
           />
-            <SidebarLink
-              to="/notenest"
-              IconComponent={Wrench}  
-              label="Tools"
-              isActive={location.pathname === "/notenest"}
-              ref={(el) => (linkRefs.current["/notenest"] = el)}
-            />        
+          <SidebarLink
+            to="/notenest"
+            IconComponent={Wrench}  
+            label="Tools"
+            isActive={location.pathname === "/notenest"}
+            ref={(el) => (linkRefs.current["/notenest"] = el)}
+          />        
           <SidebarLink
             to="/games"
             IconComponent={GamepadIcon}

--- a/Client/src/components/Sidebar.jsx
+++ b/Client/src/components/Sidebar.jsx
@@ -95,11 +95,11 @@ function Sidebar() {
             ref={(el) => (linkRefs.current["/stats"] = el)}
           />
           <SidebarLink
-            to="/games"
-            IconComponent={GamepadIcon}
-            label="Games"
-            isActive={location.pathname === "/games"}
-            ref={(el) => (linkRefs.current["/games"] = el)}
+            to="/friends"
+            IconComponent={Users}
+            label="Friends"
+            isActive={location.pathname === "/friends"}
+            ref={(el) => (linkRefs.current["/friends"] = el)}
           />
             <SidebarLink
               to="/notenest"
@@ -109,11 +109,11 @@ function Sidebar() {
               ref={(el) => (linkRefs.current["/notenest"] = el)}
             />        
           <SidebarLink
-            to="/friends"
-            IconComponent={Users}
-            label="Friends"
-            isActive={location.pathname === "/friends"}
-            ref={(el) => (linkRefs.current["/friends"] = el)}
+            to="/games"
+            IconComponent={GamepadIcon}
+            label="Games"
+            isActive={location.pathname === "/games"}
+            ref={(el) => (linkRefs.current["/games"] = el)}
           />
           
         </div>


### PR DESCRIPTION
## Description
This PR swaps the positions of the **Games** and **Friends** buttons as per issue #365.  
- The **Friends** button now appears below the **Stats** button.  
- The **Games** button is moved to the end of the navigation section.  

## Related Issue
Fixes #365  

## Changes Made
- [x] Updated navigation component to reorder **Games** and **Friends** buttons.  
- [x] Ensured proper code formatting and best practices.  
- [x] Verified functionality in all supported themes and responsive layouts.  

## Screenshots or GIFs 
<img width="808" height="892" alt="Screenshot 2025-08-17 at 6 05 48 PM" src="https://github.com/user-attachments/assets/72451a41-2616-46eb-9e01-ae2fbddad208" />



## Checklist
- [x] I have performed a self-review of my code.  
- [x] My changes are well-documented.  
- [x] I have added tests that prove my fix is effective or that my feature works.  
- [x] Any dependent changes have been merged and published.  

## Additional Notes
No other files were modified beyond what was required for this fix.  
