### PR TITLE
fix: search box text color is now visible in all themes

### DIFF
--- a/Client/src/components/session/OtherRooms.jsx
+++ b/Client/src/components/session/OtherRooms.jsx
@@ -86,7 +86,7 @@ export default function OtherRoom({ otherRooms, isLoading = false }) {
         <input
           type="text"
           placeholder="Search rooms..."
-          className="w-[270px] px-4 py-2 mb-3 border rounded-full bg-transparent text-white placeholder-gray-400 border-gray-600 "
+          className="w-[270px] px-4 py-2 mb-3 border rounded-full bg-transparent placeholder-gray-400 border-gray-600"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           disabled={isLoading}


### PR DESCRIPTION
## Description
This PR fixes the issue where the search box text was not visible in light mode. The fix ensures that the search input text color now adapts correctly with the theme.

## Related Issue
Fixes #360 

## Changes Made
- Updated search box input styling to use theme-based CSS variables for text color.
- Ensured compatibility with both light and dark modes.

## Screenshots or GIFs (if applicable)
<img width="601" height="208" alt="eduhaven1" src="https://github.com/user-attachments/assets/cc32f1fb-b291-4fff-ac3f-373400cb7999" />
<img width="502" height="183" alt="eduhaven2" src="https://github.com/user-attachments/assets/ea17c7a0-5010-4b23-9907-8377c3b048f2" />

## Checklist
- ✅ I have performed a self-review of my code.  
- ✅ Any dependent changes have been merged and published.  
