### PR TITLE
[FIX]: #364 Fix the current date background and text color

### DIFF
--- a/Client/src/components/home/calenderComponent/CalendarComponent.jsx
+++ b/Client/src/components/home/calenderComponent/CalendarComponent.jsx
@@ -256,7 +256,7 @@ function Calendar() {
                   <div
                     onClick={() => handleDayClick(day)}
                     className={`calendar-day-cell relative flex items-center justify-center p-2.5 text-sm rounded-full txt cursor-pointer transition-all duration-200 ease-in-out h-9 
-                      ${isToday ? "bg-purple-600 hover:bg-purple-700" : ""}
+                      ${isToday ? "bg-[var(--btn)] text-white" : ""}
                       ${hasEvent && !isToday ? "bg-ter hover:bg-ter" : ""}
                       ${!isToday && !hasEvent ? "hover:bg-ter" : ""}`}
                     onMouseEnter={(e) => {


### PR DESCRIPTION
## Description
Fixes the calendar's current highlighted date styling so that it correctly follows the CSS variable. Ensures the background uses `var(--btn)` and the text is white, adapting to all themes.

## Related Issue
Fixes #364 

## Changes Made
- [x] Updated calendar date styling to use `var(--btn)` for the background.  
- [x] Ensured the text color is white and visible across all themes.  
- [x] Tested across all available themes to ensure proper visibility and theme adaptation.

## Screenshots or GIFs (if applicable)
<img width="368" height="673" alt="Screenshot 2025-08-18 at 12 16 55 PM" src="https://github.com/user-attachments/assets/0d9c1a31-5095-47e2-b115-c8f16daabc84" />


## Checklist
- [x] I have performed a self-review of my code.
- [x] My changes are well-documented.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published.

## Additional Notes
Make sure to test thoroughly with all themes to confirm that the highlighted date's text is clearly visible and the background adapts correctly with the selected theme.
