### PR TITLE
[FIX]: #401 "Update" Button Text Color Blending with Dark Background 

### DIFF
--- a/Client/src/components/settings/UpdateButton.jsx
+++ b/Client/src/components/settings/UpdateButton.jsx
@@ -5,13 +5,13 @@ const UpdateButton = ({ label, isLoading, isDisabled }) => {
       disabled={isLoading || isDisabled}
       className={`px-8 py-3 rounded-lg font-semibold transition-all duration-200 shadow-lg ${
         isLoading || isDisabled
-          ? "bg-[var(--btn)] opacity-50 cursor-not-allowed"
-          : "bg-[var(--btn)] hover:bg-[var(--btn-hover)] hover:shadow-xl transform hover:-translate-y-0.5"
+          ? "bg-[var(--btn)] opacity-50 cursor-not-allowed text-white"
+          : "bg-[var(--btn)] hover:bg-[var(--btn-hover)] hover:shadow-xl transform hover:-translate-y-0.5 text-white"
       }`}
     >
       {isLoading ? (
         <div className="flex items-center">
-          <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2"></div>
+          <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2 text-white"></div>
           Updating...
         </div>
       ) : (


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what this PR does. -->
This PR fixes the visibility issue with the "Update" button in the Settings section.  
The button text was previously dark, blending with the dark background, which reduced readability and accessibility.  
The text color has now been updated to `#fff` (`text-white`) for proper contrast, ensuring consistency with other buttons like "Add".  

## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #401

## Changes Made
<!-- List the changes made in this PR. -->
- [x] Updated "Update" button text color to white for better contrast.
- [x] Ensured consistency with other buttons such as "Add".
- [x] Verified readability in dark mode against WCAG contrast guidelines.

## Screenshots
**After:** Text is clearly visible with high contrast.  

![Image](https://github.com/user-attachments/assets/44050c79-3f94-47c7-ae49-37233d944bcd)

![Image](https://github.com/user-attachments/assets/ec639333-7e09-4ef4-954a-96bb337371cf)
 

## Checklist
- [x] I have performed a self-review of my code.
- [x] My changes are well-documented.
- [x] I have added tests (if applicable) that prove my fix is effective.
- [x] Any dependent changes have been merged and published.

## Additional Notes
<!-- Add any other relevant information or context. -->
This fix improves accessibility and user experience across all subsections in Settings.
