### PR TITLE
fix: #410 prevent icons from shrinking in profile card

### DIFF
--- a/Client/src/components/stats/ProfileCard.jsx
+++ b/Client/src/components/stats/ProfileCard.jsx
@@ -347,7 +347,7 @@ const ProfileCard = ({isCurrentUser = false}) => {
       <div className="bg-gray-500/20 rounded-3xl p-4 space-y-4">
         {user.FieldOfStudy && (
           <div className="flex items-center gap-4 text-[var(--text-secondary)]">
-            <Landmark className="h-7 w-7" />
+            <Landmark className="h-7 w-7 flex-shrink-0" />
             <div>
               <p className="text-xs">{user.University || "Field of Study"}</p>
               <p className="text-lg text-[var(--text-primary)]">
@@ -360,7 +360,7 @@ const ProfileCard = ({isCurrentUser = false}) => {
 
         {user.OtherDetails?.skills && (
           <div className="flex items-center gap-4 text-[var(--text-secondary)]">
-            <Puzzle className="h-7 w-7" />
+            <Puzzle className="h-7 w-7 flex-shrink-0" />
             <div>
               <p className="text-xs">Skills</p>
               <p className="text-lg text-[var(--text-primary)]">
@@ -371,7 +371,7 @@ const ProfileCard = ({isCurrentUser = false}) => {
         )}
         {user.OtherDetails?.interests && (
           <div className="flex items-center gap-4 text-[var(--text-secondary)]">
-            <DraftingCompass className="h-7 w-7" />
+            <DraftingCompass className="h-7 w-7 flex-shrink-0" />
             <div>
               <p className="text-xs">Interests</p>
               <p className="text-lg text-[var(--text-primary)]">


### PR DESCRIPTION
## Description
Fixed icons shrinking issue in profile card when adjacent text is too long by preventing icon resize.

## Related Issue
Fixes #410

## Changes Made
- [x] Added `flex-shrink-0` class to icons to maintain consistent size.

## Screenshots or GIFs (if applicable)

Before
<img width="360" height="361" alt="Screenshot 2025-08-20 165416" src="https://github.com/user-attachments/assets/feca813c-8683-42be-a461-9ec1d59c74e5" />

After
<img width="360" height="371" alt="Screenshot 2025-08-20 165434" src="https://github.com/user-attachments/assets/8607172b-4b64-467b-a91a-2398d913f688" />


## Checklist
- [x] I have performed a self-review of my code.
- [x] My changes are well-documented.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published.


## Additional Notes

- [x] code must be properly formatted
- [x] you mustn't touch any other files if not required to solve this issue
- [x] your code is clean and follows best practices
- [x] you have clearly mentioned your changes
- [x] you have tested it with all the themes, and edge cases
- [x] you have attached multiple screenshots
