### PR TITLE
adjust Calculator dimensions based on visibility state

### DIFF
--- a/Client/src/components/home/navBar/Calculator.jsx
+++ b/Client/src/components/home/navBar/Calculator.jsx
@@ -48,8 +48,8 @@ const Calculator = () => {
           right: "20px",
           zIndex: 50,
           // pointerEvents: isChatOpen ? "auto" : "none",
-          width: "500px",
-          height: "600px",
+          width: isCalcOpen ? "500px" : "0px",
+          height: isCalcOpen ? "600px" : "0px",
         }}
       >
         <div className="bg-[var(--bg-primary)] p-2 rounded-3xl w-full h-full txt flex flex-col overflow-hidden relative shadow-2xl">


### PR DESCRIPTION
## Description
Made the calculator width and height to be zero if calculator is closed
## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #455 

## Changes Made
<!-- List the changes made in this PR. -->
- [x] Made the calculator width and height to be zero if calculator is closed

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->
Previously:
<img width="903" height="853" alt="image" src="https://github.com/user-attachments/assets/f1ba3666-e847-4b17-b665-1e0658972528" />

## Checklist
- [x] I have performed a self-review of my code.
- [x] My changes are well-documented.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published.

## Additional Notes
<!-- Add any other relevant information or context. -->
