### PR TITLE
issue #481 fixed

### DIFF
--- a/Client/src/components/stats/StudyStats.jsx
+++ b/Client/src/components/stats/StudyStats.jsx
@@ -288,6 +288,10 @@ const StudyStats = ({ stats: streakStats = {} }) => {
               }}
               itemStyle={{ color: "var(--txt)" }}
               labelStyle={{ color: "var(--btn)" }}
+              formatter={(value, name) => {
+                const num = Number(value);
+                return [Number.isInteger(num) ? num : num.toFixed(2), name];
+              }}
             />
             <Area
               type="monotone"


### PR DESCRIPTION
## Description
<!--Fixed the floating-point decimal on timer stats till 2 decimal points . Also the whole number will be displayed without trailing zeros-->

## Related Issue

Fixes #481

## Changes Made
<!-- List the changes made in this PR. -->
- [x] Updated Tooltip component 
- [x] Added formatter and also prevented whole numbers from showing `.00`.

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->
<img width="809" height="379" alt="bug solved" src="https://github.com/user-attachments/assets/772327a8-4801-4305-8532-f5472e7aa737" />


## Checklist
- [x] I have performed a self-review of my code.
- [x] My changes are well-documented.



