### PR TITLE
fix: online user's username imbalance #510

### DIFF
--- a/Client/src/components/friendsSection/OnlineFriends.jsx
+++ b/Client/src/components/friendsSection/OnlineFriends.jsx
@@ -11,6 +11,13 @@ function OnlineFriends() {
 
   const rows = [visibleUsers.slice(0, 4), visibleUsers.slice(4, 8)];
 
+  const truncate = (str) => {
+    if (str.length > 12) {
+      return str.slice(0, 10) + '...';
+    }
+    return str;
+  }
+
   return (
     <section>
       {onlineUsers.length > 0 && (
@@ -26,7 +33,7 @@ function OnlineFriends() {
                   return (
                     <div
                       key={user.id}
-                      className="flex flex-col items-center mb-3 "
+                      className="flex flex-col items-center mb-3 w-20 overflow-hidden "
                     >
                       <div className="bg-sec rounded-full overflow-hidden size-14 flex items-center justify-center">
                         {showExtra ? (
@@ -39,7 +46,7 @@ function OnlineFriends() {
                       </div>
                       {!showExtra && (
                         <h4 className="mt-2 text-sm font-medium text-center txt line-clamp-1">
-                          {user.name.split(" ")[0]}
+                          {truncate(user.name.split(" ")[0])}
                         </h4>
                       )}
                     </div>


### PR DESCRIPTION
## Description
- If the name of user is too long, it was taking too much space creating the imbalance in the UI of that section
- Given every user a fixed size

## Related Issue
Fixes #510 

## Changes Made
- [x] Given every profile a fixed size
- [x] Added a truncate function to trim the username to 10 char if its longer than that and adding ... in the end  

## Screenshots or GIFs 

before: 
<img width="407" height="278" alt="Screenshot 2025-08-26 173016" src="https://github.com/user-attachments/assets/97d6ea61-6278-45e9-ab6d-3a191dcc1c84" />

after: 
<img width="429" height="266" alt="Screenshot 2025-08-26 172812" src="https://github.com/user-attachments/assets/eadbac47-2893-4436-af42-a4c2ff751443" />


## Checklist
- [x] I have performed a self-review of my code.
- [x] My changes are well-documented.

