### PR TITLE
fix: Decline button doesn't work on friend requests #511

### DIFF
--- a/Client/src/components/friendsSection/FriendsRequests.jsx
+++ b/Client/src/components/friendsSection/FriendsRequests.jsx
@@ -27,7 +27,7 @@ function FriendRequests() {
 
   const handleReject = (friendId) => {
     axiosInstance
-      .post(`/friends/reject/${friendId}`, null)
+      .delete(`/friends/reject/${friendId}`, null)
       .then((res) => {
         console.log(res.data);
         setRequests((prev) => prev.filter((user) => user._id !== friendId));


### PR DESCRIPTION
## Description
Decline button was not working on friend requests in session page 
as the request method used there was post and the method supposed to be used there was delete

## Related Issue
Fixes #511 

## Changes Made
- [x] Updated request method to delete


## Checklist
- [x] I have performed a self-review of my code.
- [x] My changes are well-documented.
