### PR TITLE
Enhance searchParams to use replace option for better URL management

### DIFF
--- a/Client/src/pages/FriendsPage.jsx
+++ b/Client/src/pages/FriendsPage.jsx
@@ -15,7 +15,7 @@ function FriendsPage() {
 
   useEffect(() => {
     if (!searchParams.get("tab")) {
-      setSearchParams({ tab: "suggested" });
+      setSearchParams({ tab: "suggested" }, { replace: true });
     }
   }, [searchParams, setSearchParams]);
 
@@ -33,7 +33,7 @@ function FriendsPage() {
     <div className="flex h-screen overflow-hidden">
       <TabNavigation
         activeTab={activeTab}
-        onTabChange={(tab) => setSearchParams({ tab })}
+        onTabChange={(tab) => setSearchParams({ tab }, { replace: true })}
       />
       <MainContent selectedTab={activeTab} />
     </div>

--- a/Client/src/pages/Settings.jsx
+++ b/Client/src/pages/Settings.jsx
@@ -42,7 +42,7 @@ const Settings = () => {
 
   useEffect(() => {
     if (!searchParams.get("tab")) {
-      setSearchParams({ tab: "basic-info" });
+      setSearchParams({ tab: "basic-info" } , { replace: true });
     }
   }, [searchParams, setSearchParams]);
 
@@ -74,7 +74,7 @@ const Settings = () => {
     <div className="flex w-[calc(100vw-70px)] overflow-hidden m-auto">
       <Sidebar
         activeTab={activeTab}
-        setActiveTab={(tab) => setSearchParams({ tab })}
+        setActiveTab={(tab) => setSearchParams({ tab }, { replace: true })}
         user={user}
       />
       <main className="p-6 py-10 bg-primary w-full h-screen overflow-y-auto">


### PR DESCRIPTION
## Description
Fixed the naviagtion issue

## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #513 

## Changes Made
<!-- List the changes made in this PR. -->
- [x] Added replace option to be true in `setSearchParams`

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->

## Checklist
- [x] I have performed a self-review of my code.
- [x] My changes are well-documented.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published.

## Additional Notes
<!-- Add any other relevant information or context. -->
Previously, 
- you create a new tab 
- go to site (eduhaven.online)
- go to stats (/stats)
- go to tools (/tools)
- go to settings (/settings?tab=basic-info)
- go to different setting tab (say account, then education & skills etc)
- then click back button, you be at the new tab page
Now,
- you create a new tab 
- go to site (eduhaven.online)
- go to stats (/stats)
- go to tools (/tools)
- go to settings (/settings?tab=basic-info)
- go to different setting tab (say account, then education & skills etc)
- then click back button, you be /tools endpoint


