### PR TITLE
Removed Skeleton on No pending frd Requests

### DIFF
--- a/Client/src/components/friendsSection/FriendsRequests.jsx
+++ b/Client/src/components/friendsSection/FriendsRequests.jsx
@@ -5,14 +5,20 @@ import { Link } from "react-router-dom";
 
 function FriendRequests() {
   const [friendRequests, setRequests] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    setLoading(true);
     axiosInstance
       .get("/friends/requests")
       .then((res) => {
         setRequests(res.data);
+        setLoading(false);
       })
-      .catch((err) => console.error(err.response.data));
+      .catch((err) => {
+        console.error(err.response?.data);
+        setLoading(false);
+      });
   }, []);
 
   const handleAccept = (friendId) => {
@@ -32,12 +38,11 @@ function FriendRequests() {
         console.log(res.data);
         setRequests((prev) => prev.filter((user) => user._id !== friendId));
       })
-      .catch((err) => console.error(err.response.data));
+      .catch((err) => console.error(err.response?.data));
   };
 
-  const showSkeletons = friendRequests.length === 0;
-
- if (showSkeletons) {
+  // Only show skeletons when data is loading, not when there are no requests
+  if (loading) {
     return (
       <div className="bg-[var(--bg-secondary)] border border-gray-700/30 p-4 space-y-4 rounded-3xl shadow animate-pulse">
         <div className="bg-gray-500/20 h-6 rounded-md"></div>
@@ -67,7 +72,10 @@ function FriendRequests() {
     <section className="bg-sec rounded-3xl p-3 2xl:p-4">
       <h3 className="text-xl font-semibold txt">Friend Requests</h3>
       <div className="space-y-4">
-        {friendRequests.map((user) => (
+        {friendRequests.length === 0 ? (
+          <p className="text-center py-4 txt-dim">No pending friend requests</p>
+        ) : (
+          friendRequests.map((user) => (
           <div key={user.id} className="!mt-7">
             <div className="flex items-center">
               <Link to={`/user/${user._id}`}>
@@ -110,7 +118,7 @@ function FriendRequests() {
               </button>
             </div>
           </div>
-        ))}
+        )))}
       </div>
     </section>
   );

--- a/Client/src/components/friendsSection/SentRequests.jsx
+++ b/Client/src/components/friendsSection/SentRequests.jsx
@@ -2,31 +2,35 @@ import { useEffect, useState } from "react";
 import axiosInstance from "@/utils/axios";
 import { ArrowLeft, User } from "lucide-react";
 import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
 
 function SentRequests({ onBack }) {
   const [sentRequests, setSentRequests] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    setLoading(true);
     axiosInstance
       .get("/friends/sent-requests")
       .then((response) => {
         setSentRequests(response.data);
+        setLoading(false);
       })
       .catch((error) => {
         console.error("Error fetching sent requests:", error);
+        setLoading(false);
       });
   }, []);
 
-  const showSkeletons = sentRequests.length === 0;
-
-     if (showSkeletons) {
+  // Only show skeletons when data is loading, not when there are no requests
+  if (loading) {
     return (
       <div className="bg-[var(--bg-secondary)] border border-gray-700/30 p-4 rounded-3xl shadow flex flex-col justify-center animate-pulse">
         <div className="w-full mb-4 h-8 bg-gray-500/20 rounded-md"></div>
         {Array(4)
           .fill()
-          .map((_, i) => (
-            <div className="flex justify-between items-center space-x-2 my-2">
+          .map((_, index) => (
+            <div key={index} className="flex justify-between items-center space-x-2 my-2">
               <div className="w-10 aspect-square bg-gray-500/20 rounded-full"></div>
               <div className="flex-1 flex flex-col justify-center *:items-start space-y-2">
               <div className=" bg-gray-500/20 w-full h-4 rounded-md"></div>
@@ -83,5 +87,9 @@ function SentRequests({ onBack }) {
     </section>
   );
 }
+
+SentRequests.propTypes = {
+  onBack: PropTypes.func.isRequired
+};
 
 export default SentRequests;


### PR DESCRIPTION
## Description
Changed the skeleton loading condition to only show when actually loading data, not when there are no requests
Added a "No pending friend requests" message when there are no requests but loading is complete

## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #530 

## Changes Made
<!-- List the changes made in this PR. -->
- [x] Updated FriendRequests.jsx file to handle the logic
- [x] Added extra validation on loading the pending requests

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->

## Checklist
- [x] I have performed a self-review of my code.
- [x] My changes are well-documented.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published.

## Additional Notes

