### PR TITLE
Fix: The user profile gets squeezed if it has longer Bio

### DIFF
--- a/Client/src/components/friendsSection/FriendsRequests.jsx
+++ b/Client/src/components/friendsSection/FriendsRequests.jsx
@@ -60,7 +60,7 @@ function FriendRequests() {
                   <User className="w-7 h-7" />
                 </div>
               )}
-              <div className="ml-4 min-w-[163px]">
+              <div className="ml-4 overflow-hidden">
                 <h4 className="text-lg font-medium line-clamp-1 txt">
                   {user.FirstName
                     ? `${user.FirstName} ${user.LastName || ""}`


### PR DESCRIPTION

## Description
<!-- A clear and concise description of what this PR does. -->
Adjust the width of the username and description container within the friend request component to prevent text overflow. The current layout is causing the text to overflow instead of shrinking the avatar.


## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #509

## Changes Made
<!-- List the changes made in this PR. -->
- [FriendsRequest.jsx 63]: set a min-w 

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->
<img width="296" height="250" alt="image" src="https://github.com/user-attachments/assets/a13d5495-cad7-4768-a933-4b4ec3fabf3d" />


## Checklist
- [x ] I have performed a self-review of my code.
- [x ] My changes are well-documented.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x ] Any dependent changes have been merged and published.

## Additional Notes
<!-- Add any other relevant information or context. -->
