### PR TITLE
Updated whac-a-mole instruction

### DIFF
--- a/Client/src/components/games/whac-a-mole/Whacamole.jsx
+++ b/Client/src/components/games/whac-a-mole/Whacamole.jsx
@@ -226,15 +226,22 @@ const Whacamole = () => {
         <div className="fixed inset-0 flex items-center justify-center bg-black/70 z-30">
           <div className="bg-white/10 backdrop-blur-md p-6 rounded-2xl max-w-md text-center">
             <h2 className="text-3xl font-bold text-white mb-4">How to Play</h2>
-            <p className="text-white mb-4">
-              Whac-A-Mole is a fast-paced reflex game! 🐹 - Tap the{" "}
-              <span className="font-bold">Moles</span> to earn points (+10).{" "}
-              Avoid clicking on the{" "}
-              <span className="font-bold text-red-400">Evil Plants</span>{" "}
-              hitting one ends the game instantly. - If you miss a Mole, you
-              lose 5 points. - The game lasts 30 seconds. Try to beat your High
-              Score!
-            </p>
+            <ul className="text-white mb-4 list-disc list-inside text-left space-y-2">
+              <li>
+                Tap the <span className="font-bold">Moles </span>🦦 to earn points 
+                (<span className="font-bold text-green-600">+10</span>).
+              </li>
+              <li>
+                Avoid the <span className="font-bold text-red-400">Evil Plants🌱</span>- one hit ends the game.
+              </li>
+              <li>
+                Missing a <span className="font-bold">Mole </span>🦦 costs you 
+                <span className="font-bold text-red-400"> -5 points</span>.
+              </li>
+              <li>
+                The game lasts <span className="font-bold">30 seconds </span>⏱️- try to beat your High Score!
+              </li>
+            </ul>
             <button
               onClick={() => setShowInstructions(false)}
               className="px-6 py-2 bg-green-500 text-white font-semibold rounded-full shadow-md hover:opacity-90 transition"


### PR DESCRIPTION
## Description
Updated the Whac-A-Mole game instructions to be more concise, visually appealing, and easier to read. Added bullet points with bold highlights and colored text for rewards and penalties.

## Related Issue
Fixes #649 

## Changes Made
- Converted game rules into a bullet-point list.
- Highlighted key terms: Moles 🦦 in bold, Evil Plants 🌱 in bold red.
- Used green for positive points and red for penalties.
- Shortened and simplified sentences for clarity and readability.

## Screenshots or GIFs (if applicable)
Before
<img width="1919" height="876" alt="Screenshot 2025-09-06 131214" src="https://github.com/user-attachments/assets/91670272-25ae-4918-8e97-1f42b97af70c" />

After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fa7bbef5-fd73-4961-98ba-bb26d8ee4b67" />


## checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.