### PR TITLE
Add color customization to NoteEditor and define color variables in CSS

### DIFF
--- a/Client/src/components/notes/NoteEditor.jsx
+++ b/Client/src/components/notes/NoteEditor.jsx
@@ -23,6 +23,7 @@ import ToolbarButton from "./ToolbarButton";
 const NoteEditor = ({
   selectedNote,
   setSelectedNote,
+  colors,
   editor,
   updateNote,
   insertLink,
@@ -32,7 +33,11 @@ const NoteEditor = ({
   return (
     <div
       className="flex-1 flex flex-col rounded-tl-3xl"
-      style={{ backgroundColor: "var(--bg-ter)" }}
+      style={{
+        backgroundColor: colors.find((c) => c.name === selectedNote.color)
+          ?.style.backgroundColor,
+        color: "var(--txt)",
+      }}
     >
       {/* Editor Header */}
       <div

--- a/Client/src/components/notes/note.css
+++ b/Client/src/components/notes/note.css
@@ -1,3 +1,14 @@
+:root {
+  --note-default: rgba(128, 128, 128, 0.15);
+  --note-red: rgba(255, 99, 71, 0.2);
+  --note-orange: rgba(255, 165, 0, 0.2);
+  --note-yellow: rgba(255, 223, 0, 0.2);
+  --note-green: rgba(50, 205, 50, 0.2);
+  --note-blue: rgba(70, 130, 180, 0.2);
+  --note-purple: rgba(138, 43, 226, 0.2);
+  --note-pink: rgba(255, 105, 180, 0.2);
+}
+
 * {
   box-sizing: border-box;
 }

--- a/Client/src/pages/Notes.jsx
+++ b/Client/src/pages/Notes.jsx
@@ -21,14 +21,14 @@ import NotesList from "@/components/notes/NotesList.jsx";
 import "@/components/notes/note.css";
 
 const colors = [
-  { name: "default", style: { backgroundColor: "var(--bg-sec)" } },
-  { name: "red", style: { backgroundColor: "var(--red-light)" } },
-  { name: "orange", style: { backgroundColor: "var(--orange-light)" } },
-  { name: "yellow", style: { backgroundColor: "var(--yellow-light)" } },
-  { name: "green", style: { backgroundColor: "var(--green-light)" } },
-  { name: "blue", style: { backgroundColor: "var(--blue-light)" } },
-  { name: "purple", style: { backgroundColor: "var(--purple-light)" } },
-  { name: "pink", style: { backgroundColor: "var(--pink-light)" } },
+  { name: "default", style: { backgroundColor: "var(--note-default)" } },
+  { name: "red", style: { backgroundColor: "var(--note-red)" } },
+  { name: "orange", style: { backgroundColor: "var(--note-orange)" } },
+  { name: "yellow", style: { backgroundColor: "var(--note-yellow)" } },
+  { name: "green", style: { backgroundColor: "var(--note-green)" } },
+  { name: "blue", style: { backgroundColor: "var(--note-blue)" } },
+  { name: "purple", style: { backgroundColor: "var(--note-purple)" } },
+  { name: "pink", style: { backgroundColor: "var(--note-pink)" } },
 ];
 
 const Notes = () => {
@@ -259,6 +259,7 @@ const Notes = () => {
           <NoteEditor
             selectedNote={selectedNote}
             setSelectedNote={setSelectedNote}
+            colors={colors}
             editor={editor}
             updateNote={updateNote}
             insertLink={insertLink}
@@ -267,7 +268,6 @@ const Notes = () => {
           />
         )}
       </div>
-
     </div>
   );
 };


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what this PR does. -->
Made colors to be selected and change the color of the notes

## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #655

## Changes Made
<!-- List the changes made in this PR. -->
- [x] Added variables in `note.css`

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->
<img width="1411" height="761" alt="image" src="https://github.com/user-attachments/assets/dafc682c-a88a-4d6a-8d4f-0835333c5dc1" />
<img width="1285" height="647" alt="image" src="https://github.com/user-attachments/assets/8dba2c31-d0a7-43b0-aafa-15212a1adebc" />
<img width="1437" height="774" alt="image" src="https://github.com/user-attachments/assets/c55875ff-6438-43c5-89e0-474d07be9d9e" />

## checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.

## Additional Notes
<!-- Add any other relevant information or context. -->
