### PR TITLE
Refactor NoteCard component: streamline color picker and hover functionality

### DIFF
--- a/Client/src/components/notes/NoteCard.jsx
+++ b/Client/src/components/notes/NoteCard.jsx
@@ -1,11 +1,4 @@
-import {
-  Copy,
-  Download,
-  MoreVertical,
-  Palette,
-  Pin,
-  Trash2,
-} from "lucide-react";
+import { Copy, Download, Palette, Pin, Trash2, UserPlus } from "lucide-react";
 import { useState } from "react";
 
 const NoteCard = ({
@@ -21,7 +14,7 @@ const NoteCard = ({
   colors,
   getPlainTextPreview,
 }) => {
-  const [showMenu, setShowMenu] = useState(false);
+  const [hovered, setHovered] = useState(false);
 
   const getColorStyle = (colorName) => {
     const color = colors.find((c) => c.name === colorName);
@@ -36,172 +29,116 @@ const NoteCard = ({
 
   return (
     <div
-      className="cursor-pointer relative flex flex-col transition-all p-4 rounded-xl"
+      className="cursor-pointer relative flex flex-col transition-all p-4 rounded-xl group"
       style={{
         ...getColorStyle(note.color),
-        minHeight: "120px",
+        minHeight: "140px",
       }}
       onClick={() => onSelect(note)}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
     >
-      <div className="flex items-start justify-between mb-2">
-        <div className="flex-1">
-          {note.title && (
-            <h3
-              className="text-sm font-semibold m-0 mb-1.5 leading-tight"
-              style={{ color: "var(--txt)" }}
-            >
-              {truncateText(note.title, 40)}
-            </h3>
-          )}
-          <div
-            className="text-xs leading-snug"
-            style={{ color: "var(--txt-dim)" }}
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onPin(note.id);
+        }}
+        className="absolute top-2 right-2 p-1 rounded-full bg-black/10 hover:bg-black/20"
+      >
+        <Pin
+          size={16}
+          style={{
+            color: note.isPinned ? "var(--btn)" : "var(--txt-dim)",
+          }}
+        />
+      </button>
+
+      <div className="flex-1">
+        {note.title && (
+          <h3
+            className="text-sm font-semibold m-0 mb-1.5 leading-tight"
+            style={{ color: "var(--txt)" }}
           >
-            {truncateText(getPlainTextPreview(note.content), 100)}
-          </div>
-        </div>
-
-        <div className="relative">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setShowMenu(!showMenu);
-            }}
-            className="p-1 border-none bg-transparent cursor-pointer opacity-70 rounded"
-            style={{ color: "var(--txt-dim)" }}
-          >
-            <MoreVertical size={16} />
-          </button>
-
-          {showMenu && (
-            <div
-              className="absolute top-full right-0 border z-10 shadow-lg"
-              style={{
-                backgroundColor: "var(--bg-ter)",
-                borderColor: "var(--bg-sec)",
-                borderRadius: "var(--radius)",
-                minWidth: "150px",
-              }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onPin(note.id);
-                  setShowMenu(false);
-                }}
-                className="w-full py-2 px-3 border-none bg-transparent text-left cursor-pointer flex items-center gap-2 text-sm rounded"
-                style={{ color: "var(--txt)" }}
-              >
-                <Pin size={14} />
-                {note.isPinned ? "Unpin" : "Pin"}
-              </button>
-
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setShowColorPicker(
-                    showColorPicker === note.id ? null : note.id
-                  );
-                }}
-                className="w-full py-2 px-3 border-none bg-transparent text-left cursor-pointer flex items-center gap-2 text-sm rounded"
-                style={{ color: "var(--txt)" }}
-              >
-                <Palette size={14} />
-                Color
-              </button>
-
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDuplicate(note);
-                  setShowMenu(false);
-                }}
-                className="w-full py-2 px-3 border-none bg-transparent text-left cursor-pointer flex items-center gap-2 text-sm rounded"
-                style={{ color: "var(--txt)" }}
-              >
-                <Copy size={14} />
-                Duplicate
-              </button>
-
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onExport(note);
-                  setShowMenu(false);
-                }}
-                className="w-full py-2 px-3 border-none bg-transparent text-left cursor-pointer flex items-center gap-2 text-sm rounded"
-                style={{ color: "var(--txt)" }}
-              >
-                <Download size={14} />
-                Export
-              </button>
-
-              <hr
-                className="my-1 border-none border-t"
-                style={{ borderColor: "var(--bg-sec)" }}
-              />
-
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDelete(note.id);
-                  setShowMenu(false);
-                }}
-                className="w-full py-2 px-3 border-none bg-transparent text-left cursor-pointer flex items-center gap-2 text-sm rounded"
-                style={{ color: "var(--danger)" }}
-              >
-                <Trash2 size={14} />
-                Delete
-              </button>
-            </div>
-          )}
-
-          {showColorPicker === note.id && (
-            <div
-              className="absolute top-full right-0 border p-2 shadow-lg z-20 flex gap-1 flex-wrap"
-              style={{
-                backgroundColor: "var(--bg-ter)",
-                borderColor: "var(--bg-sec)",
-                borderRadius: "var(--radius)",
-                width: "120px",
-              }}
-              onClick={(e) => e.stopPropagation()}
-            >
-              {colors.map((color) => (
-                <button
-                  key={color.name}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onColorChange(note.id, color.name);
-                  }}
-                  className="w-6 h-6 cursor-pointer rounded-full border"
-                  style={{
-                    ...color.style,
-                    borderColor:
-                      note.color === color.name
-                        ? "var(--btn)"
-                        : "var(--bg-sec)",
-                    borderWidth: note.color === color.name ? "2px" : "1px",
-                  }}
-                />
-              ))}
-            </div>
-          )}
+            {truncateText(note.title, 40)}
+          </h3>
+        )}
+        <div
+          className="text-xs leading-snug"
+          style={{ color: "var(--txt-dim)" }}
+        >
+          {truncateText(getPlainTextPreview(note.content), 100)}
         </div>
       </div>
 
-      {note.isPinned && (
-        <Pin
-          size={12}
-          className="absolute top-2 right-8"
-          style={{ color: "var(--btn)" }}
-        />
-      )}
-
-      <div className="text-xs mt-auto" style={{ color: "var(--txt-disabled)" }}>
+      <div className="text-xs mt-2" style={{ color: "var(--txt-disabled)" }}>
         {new Date(note.createdAt).toLocaleDateString()}
       </div>
+
+      {hovered && (
+        <div
+          className="absolute bottom-2 left-2 right-2 flex justify-between items-center gap-2 px-2 py-1 rounded-lg"
+          style={{ backgroundColor: "var(--bg-ter)" }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <button
+            onClick={() =>
+              setShowColorPicker(showColorPicker === note.id ? null : note.id)
+            }
+            className="p-1 rounded hover:bg-black/10"
+          >
+            <Palette size={16} />
+          </button>
+
+          <button
+            onClick={() => onDuplicate(note)}
+            className="p-1 rounded hover:bg-black/10"
+          >
+            <Copy size={16} />
+          </button>
+
+          <button
+            onClick={() => onExport(note)}
+            className="p-1 rounded hover:bg-black/10"
+          >
+            <Download size={16} />
+          </button>
+
+          <button
+            disabled
+            className="p-1 rounded opacity-40 cursor-not-allowed"
+          >
+            <UserPlus size={16} />
+          </button>
+
+          <button
+            onClick={() => onDelete(note.id)}
+            className="p-1 rounded hover:bg-black/10"
+          >
+            <Trash2 size={16} />
+          </button>
+        </div>
+      )}
+
+      {showColorPicker === note.id && (
+        <div
+          className="absolute bottom-12 left-2 border p-2 shadow-lg z-20 flex gap-1 flex-wrap bg-[var(--bg-ter)] rounded-lg"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {colors.map((color) => (
+            <button
+              key={color.name}
+              onClick={() => onColorChange(note.id, color.name)}
+              className="w-6 h-6 cursor-pointer rounded-full border"
+              style={{
+                ...color.style,
+                borderColor:
+                  note.color === color.name ? "var(--btn)" : "var(--bg-sec)",
+                borderWidth: note.color === color.name ? "2px" : "1px",
+              }}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/Client/src/components/notes/NoteCard.jsx
+++ b/Client/src/components/notes/NoteCard.jsx
@@ -43,12 +43,15 @@ const NoteCard = ({
           e.stopPropagation();
           onPin(note.id);
         }}
-        className="absolute top-2 right-2 p-1 rounded-full bg-black/10 hover:bg-black/20"
+        className={`absolute top-2 right-2 p-1 rounded-full bg-black/10 hover:bg-black/20 transition-opacity
+        ${note.isPinned ? "opacity-100" : hovered ? "opacity-100" : "opacity-0"}`}
       >
         <Pin
           size={16}
           style={{
             color: note.isPinned ? "var(--btn)" : "var(--txt-dim)",
+            transform: note.isPinned ? "rotate(45deg)" : "rotate(0deg)",
+            transition: "transform 0.2s ease",
           }}
         />
       </button>


### PR DESCRIPTION
## Description
Updated the dropdown ui
## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #656

## Changes Made
<!-- List the changes made in this PR. -->
- [x] Updated the dropdown ui such that the color, duplicate, export, user add, and delete button are shown only on hover and pin button is on the top

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->
<img width="1273" height="495" alt="image" src="https://github.com/user-attachments/assets/d3e1ec0d-8a56-47d0-a62d-b50336d3e2b3" />

## checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.

## Additional Notes
<!-- Add any other relevant information or context. -->
