### PR TITLE
Fix the bullet points not showing in notes

### DIFF
--- a/Client/src/components/notes/note.css
+++ b/Client/src/components/notes/note.css
@@ -57,6 +57,14 @@ body {
   margin: 0.5em 0;
 }
 
+.ProseMirror ul {
+  list-style-type: disc;
+}
+
+.ProseMirror ol {
+  list-style-type: decimal;
+}
+
 .ProseMirror li {
   margin: 0.25em 0;
 }


### PR DESCRIPTION
## Description
The lists created in /notes page did not show bullet points or numbering for the items. So i fixed the part in css file that caused the error and now that part is functional now.

## Related Issue
Fixes #667 

## Changes Made
- updated notes.css

## Screenshots or GIFs (if applicable)
<img width="1781" height="805" alt="image" src="https://github.com/user-attachments/assets/dd14ab22-0f8d-4f72-9068-d3bf721890e0" />


## checklist

- [ ] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [ ] Only the necessary files are modified; no unrelated changes are included.
- [ ] Follows clean code principles (readable, maintainable, minimal duplication).
- [ ] All changes are clearly documented.
- [ ] Code has been tested across all supported themes and verified against potential edge cases.
- [ ] Multiple screenshots or recordings are attached (if required).
- [ ] No breaking changes are introduced to existing functionality.
