### PR TITLE
fix: corrected auth page footer text

### DIFF
--- a/Client/src/Auth/Login.jsx
+++ b/Client/src/Auth/Login.jsx
@@ -172,7 +172,7 @@ function Login() {
           className="text-blue-600 dark:text-blue-400 font-medium hover:text-blue-700 dark:hover:text-blue-300 transition-colors duration-200 px-4 py-2 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20"
           to="/auth/signup"
         >
-          Already have an account? Sign in
+          Do not have an account? Sign up
         </Link>
       </motion.div>
     </div>

--- a/Client/src/Auth/SignUp.jsx
+++ b/Client/src/Auth/SignUp.jsx
@@ -255,7 +255,7 @@ function SignUp() {
           className="text-blue-600 dark:text-blue-400 font-medium hover:text-blue-700 dark:hover:text-blue-300 transition-colors duration-200 px-4 py-2 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20"
           to="/auth/login"
         >
-          Do not have an account? Sign up
+          Already have an account? Sign in
         </Link>
       </motion.div>
     </div>


### PR DESCRIPTION
## Description
- On the **Login page**, the "Do nothave an account? Sign Up" link text now shows correctly.  
- On the **Sign Up page**, the "Already have an account? Sign In" link text now shows correctly.

## Related Issue
Fixes #717 

## Changes Made
- Updated Login.jsx and SignUp.jsx files by changing the footer texts of those pages to the correct one.

Only the text was changed as mentioned in the issue and nothing else was touched.

## Screenshots or GIFs (if applicable)
LOGIN PAGE
before
<img width="1915" height="879" alt="image" src="https://github.com/user-attachments/assets/985cf47a-7d27-459b-b4e5-47c8a6b549c1" />

after
<img width="842" height="897" alt="image" src="https://github.com/user-attachments/assets/fc90fdc1-7d10-4793-a1e2-53576b46bf2b" />


SINGUP PAGE
before
<img width="1231" height="888" alt="image" src="https://github.com/user-attachments/assets/4c08609b-c9bf-4a66-8bb3-b604438ee8ba" />

after
<img width="895" height="898" alt="image" src="https://github.com/user-attachments/assets/51aca94b-7027-4765-8a23-14baa07bbbce" />