### PR TITLE
slogan hide

### DIFF
--- a/Client/src/components/home/navBar/OnlineUsers.jsx
+++ b/Client/src/components/home/navBar/OnlineUsers.jsx
@@ -14,7 +14,9 @@ export default function OnlineUsers() {
           ))}
         </div>
       )}
-      <h2 className="font-semibold txt">{onlineUsers.length} online</h2>
+      <h2 className="font-semibold txt whitespace-nowrap">
+        {`${onlineUsers.length} online`}
+      </h2>
     </div>
   );
 }

--- a/Client/src/components/home/navBar/Slogan.jsx
+++ b/Client/src/components/home/navBar/Slogan.jsx
@@ -8,7 +8,6 @@ function Slogan() {
   const [author, setAuthor] = useState("");
   const [displayMode, setDisplayMode] = useState("greeting");
   const [firstName, setFirstName] = useState("User");
-  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
   const getFirstNameFromJWT = () => {
     const token = localStorage.getItem("token");
@@ -207,13 +206,6 @@ function Slogan() {
     return () => clearTimeout(timer);
   }, [displayMode]);
 
-  // Track screen size changes
-  useEffect(() => {
-    const handleResize = () => setWindowWidth(window.innerWidth);
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
   const textVariants = {
     initial: { opacity: 0, y: 20, filter: "blur(10px)" },
     animate: {
@@ -230,13 +222,6 @@ function Slogan() {
     },
   };
 
-  // Helper for responsive font
-  const getFontSize = () => {
-    if (windowWidth < 640) return "text-sm";
-    if (windowWidth < 1024) return "text-base";
-    return "text-lg";
-  };
-
   return (
     <div className="slogan flex items-center justify-center relative group min-h-[3rem] px-2 w-full">
       <AnimatePresence mode="wait">
@@ -248,12 +233,9 @@ function Slogan() {
           exit="exit"
           className="text-center w-full max-w-full px-2 md:px-4"
         >
-          {/* Show greeting always, show quote only on larger screens */}
-          {displayMode === "quote" && windowWidth >= 768 ? (
-            <div className="flex items-center justify-center gap-2 md:gap-4 flex-wrap">
-              <div
-                className={`${getFontSize()} font-semibold break-words max-w-full`}
-              >
+          {displayMode === "quote" ? (
+            <div className="hidden md:flex items-center justify-center gap-2 md:gap-4 flex-nowrap whitespace-nowrap overflow-hidden text-ellipsis">
+              <div className="font-semibold break-words max-w-full">
                 {quote}
               </div>
               <motion.div
@@ -267,9 +249,7 @@ function Slogan() {
               </motion.div>
             </div>
           ) : (
-            <div className={`${getFontSize()} font-semibold truncate`}>
-              {getGreeting()}
-            </div>
+            <div className="font-semibold truncate">{getGreeting()}</div>
           )}
         </motion.div>
       </AnimatePresence>

--- a/Client/src/components/home/navBar/Slogan.jsx
+++ b/Client/src/components/home/navBar/Slogan.jsx
@@ -8,6 +8,7 @@ function Slogan() {
   const [author, setAuthor] = useState("");
   const [displayMode, setDisplayMode] = useState("greeting");
   const [firstName, setFirstName] = useState("User");
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
   const getFirstNameFromJWT = () => {
     const token = localStorage.getItem("token");
@@ -119,10 +120,7 @@ function Slogan() {
         quote: "The struggle you’re in today builds strength for tomorrow.",
         author: "Unknown",
       },
-      {
-        quote: "If it matters to you, you’ll find a way.",
-        author: "Unknown",
-      },
+      { quote: "If it matters to you, you’ll find a way.", author: "Unknown" },
       {
         quote: "The harder you work, the luckier you get.",
         author: "Gary Player",
@@ -131,34 +129,19 @@ function Slogan() {
         quote: "Great things never come from comfort zones.",
         author: "Unknown",
       },
-      {
-        quote: "Success is earned, not given.",
-        author: "Unknown",
-      },
+      { quote: "Success is earned, not given.", author: "Unknown" },
       {
         quote: "Don’t watch the clock; do what it does — keep going.",
         author: "Sam Levenson",
       },
-      {
-        quote: "Believe in your hustle.",
-        author: "Unknown",
-      },
-      {
-        quote: "Dream it. Wish it. Do it.",
-        author: "Unknown",
-      },
+      { quote: "Believe in your hustle.", author: "Unknown" },
+      { quote: "Dream it. Wish it. Do it.", author: "Unknown" },
       {
         quote: "Don’t limit your challenges, challenge your limits.",
         author: "Jerry Dunn",
       },
-      {
-        quote: "You are stronger than your excuses.",
-        author: "Unknown",
-      },
-      {
-        quote: "Focus on the goal, not the obstacle.",
-        author: "Unknown",
-      },
+      { quote: "You are stronger than your excuses.", author: "Unknown" },
+      { quote: "Focus on the goal, not the obstacle.", author: "Unknown" },
       {
         quote: "It always seems impossible until it's done.",
         author: "Nelson Mandela",
@@ -171,7 +154,6 @@ function Slogan() {
   const shouldRefreshQuote = () => {
     const cachedDate = localStorage.getItem("quoteTimestamp");
     if (!cachedDate) return true;
-
     const ninetyMinAgo = Date.now() - 180 * 60 * 1000;
     return parseInt(cachedDate) < ninetyMinAgo;
   };
@@ -186,7 +168,6 @@ function Slogan() {
       localStorage.setItem("dailyQuote", fetchedData.quote);
       localStorage.setItem("quoteAuthor", fetchedData.author);
       localStorage.setItem("quoteTimestamp", Date.now().toString());
-      console.log("Quote refreshed:", fetchedData);
     } catch (error) {
       setQuote("Failed to fetch quote.");
       setAuthor("Try again");
@@ -207,16 +188,13 @@ function Slogan() {
     if (cachedQuote && !shouldRefreshQuote()) {
       setQuote(cachedQuote);
       setAuthor(cachedAuthor || "");
-      // console.log("Using cached quote:", cachedQuote);
     } else {
-      // console.log("Fetching new quote...");
       fetchQuote().then((fetchedData) => {
         setQuote(fetchedData.quote);
         setAuthor(fetchedData.author);
         localStorage.setItem("dailyQuote", fetchedData.quote);
         localStorage.setItem("quoteAuthor", fetchedData.author);
         localStorage.setItem("quoteTimestamp", Date.now().toString());
-        console.log("New quote fetched:", fetchedData);
       });
     }
   }, []);
@@ -226,38 +204,41 @@ function Slogan() {
     const timer = setTimeout(() => {
       setDisplayMode((prev) => (prev === "greeting" ? "quote" : "greeting"));
     }, duration);
-
     return () => clearTimeout(timer);
   }, [displayMode]);
 
+  // Track screen size changes
+  useEffect(() => {
+    const handleResize = () => setWindowWidth(window.innerWidth);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   const textVariants = {
-    initial: {
-      opacity: 0,
-      y: 20,
-      filter: "blur(10px)",
-    },
+    initial: { opacity: 0, y: 20, filter: "blur(10px)" },
     animate: {
       opacity: 1,
       y: 0,
       filter: "blur(0px)",
-      transition: {
-        duration: 0.4,
-        ease: "easeOut",
-      },
+      transition: { duration: 0.4, ease: "easeOut" },
     },
     exit: {
       opacity: 0,
       y: -20,
       filter: "blur(10px)",
-      transition: {
-        duration: 0.2,
-        ease: "easeIn",
-      },
+      transition: { duration: 0.2, ease: "easeIn" },
     },
   };
 
+  // Helper for responsive font
+  const getFontSize = () => {
+    if (windowWidth < 640) return "text-sm";
+    if (windowWidth < 1024) return "text-base";
+    return "text-lg";
+  };
+
   return (
-    <div className="slogan text-2xl font-semibold txt min-h-[3rem] flex items-center justify-center relative group">
+    <div className="slogan flex items-center justify-center relative group min-h-[3rem] px-2 w-full">
       <AnimatePresence mode="wait">
         <motion.div
           key={displayMode + (displayMode === "quote" ? quote : getGreeting())}
@@ -265,23 +246,30 @@ function Slogan() {
           initial="initial"
           animate="animate"
           exit="exit"
-          className="text-center max-w-4xl px-4"
+          className="text-center w-full max-w-full px-2 md:px-4"
         >
-          {displayMode === "quote" ? (
-            <div className="flex items-end gap-4">
-              <div>{quote}</div>
+          {/* Show greeting always, show quote only on larger screens */}
+          {displayMode === "quote" && windowWidth >= 768 ? (
+            <div className="flex items-center justify-center gap-2 md:gap-4 flex-wrap">
+              <div
+                className={`${getFontSize()} font-semibold break-words max-w-full`}
+              >
+                {quote}
+              </div>
               <motion.div
                 whileHover={{ rotate: -360 }}
                 transition={{ duration: 0.5, ease: "easeInOut" }}
-                className="txt-dim opacity-0 group-hover:opacity-100 transition-opacity duration-300 cursor-pointer"
+                className="txt-dim opacity-0 group-hover:opacity-100 transition-opacity duration-300 cursor-pointer flex-shrink-0"
                 onClick={handleIconClick}
                 title="Refresh Quote"
               >
-                <RotateCcw size={20} />
+                <RotateCcw className="w-4 h-4 md:w-5 md:h-5" />
               </motion.div>
             </div>
           ) : (
-            getGreeting()
+            <div className={`${getFontSize()} font-semibold truncate`}>
+              {getGreeting()}
+            </div>
           )}
         </motion.div>
       </AnimatePresence>


### PR DESCRIPTION
Description
This PR hides the quote section (slogan) on smaller screens to reduce the navbar height and improve responsiveness. When the screen width is below 768px, the quote will not be shown.

Related Issue
Fixes #729

Changes Made
 Added responsive logic to hide the quote when screen width is below 768px.
 Used a useEffect hook to track window resizing and toggle the quote visibility.
 Improved UI responsiveness and layout on smaller screens.
Screenshots or GIFs 


Checklist
 Code is formatted with the project’s Prettier config provided in .prettierrc.
 Only the necessary files are modified; no unrelated changes are included.
 Follows clean code principles (readable, maintainable, minimal duplication).
 All changes are clearly documented.
 Code has been tested across all supported themes and verified against potential edge cases.
 No breaking changes are introduced to existing functionality.

https://github.com/user-attachments/assets/9d0643a7-9837-4724-8dee-88e0f2fb46ad

