### PR TITLE
fix(ui): align skeleton and friends page tabs layout with suggestions tab layout

### DIFF
--- a/Client/src/components/friendsPage/MainContent.jsx
+++ b/Client/src/components/friendsPage/MainContent.jsx
@@ -35,7 +35,7 @@ function MainContent({ selectedTab }) {
   };
 
   return (
-    <div className="flex-1 pt-3 pr-3 2xl:pt-6 2xl:pr-6 pb-8 overflow-y-auto">
+    <div className="ml-3 flex-1 pt-3 pr-3 2xl:pt-6 2xl:pr-6 pb-8 overflow-y-auto">
       <h2 className="text-2xl font-semibold mb-4 text-[var(--txt)]">
         {getTitle()}
       </h2>

--- a/Client/src/components/friendsPage/TabNavigation.jsx
+++ b/Client/src/components/friendsPage/TabNavigation.jsx
@@ -7,7 +7,7 @@ function TabNavigation({ activeTab, onTabChange }) {
   ];
 
   return (
-    <div className="w-60 overflow-hidden hidden sm:flex flex-col p-4 h-screen mr-3 2xl:mr-6 bg-[var(--bg-sec)]">
+    <div className="w-60 overflow-hidden hidden sm:flex flex-col p-4 h-screen 2xl:mr-6 bg-[var(--bg-sec)]">
       <h3 className="text-xl font-semibold mb-4 text-[var(--txt)]">Friends</h3>
       <div className="space-y-2">
         {tabs.map((tab) => (

--- a/Client/src/components/friendsPage/tabs/AllFriends.jsx
+++ b/Client/src/components/friendsPage/tabs/AllFriends.jsx
@@ -47,8 +47,7 @@ export default function AllFriends() {
         <SearchBar onSearch={handleSearch} placeholder="Search friends..." />
       )}
 
-      {/* 4. Update container to use CSS Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
+      <div className="flex flex-wrap justify-center gap-3 2xl:gap-4 mt-4">
         {filteredFriends.map((user) => (
           <UserCard key={user._id} user={user} selectedTab="allFriends" />
         ))}

--- a/Client/src/components/friendsPage/tabs/FriendRequests.jsx
+++ b/Client/src/components/friendsPage/tabs/FriendRequests.jsx
@@ -48,8 +48,7 @@ export default function FriendRequests() {
         />
       )}
 
-      {/* 4. Update container to use CSS Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
+      <div className="flex flex-wrap justify-center gap-3 2xl:gap-4 mt-4">
         {filteredRequests.map((user) => (
           <UserCard key={user._id} user={user} selectedTab="friendRequests" />
         ))}

--- a/Client/src/components/friendsPage/tabs/SentRequests.jsx
+++ b/Client/src/components/friendsPage/tabs/SentRequests.jsx
@@ -48,7 +48,7 @@ export default function SentRequests() {
         />
       )}
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
+      <div className="flex flex-wrap justify-center gap-3 2xl:gap-4 mt-4">
         {filteredSent?.map((user) => (
           <UserCard key={user._id} user={user} selectedTab="sentRequests" />
         ))}

--- a/Client/src/components/friendsPage/tabs/SuggestedFriends.jsx
+++ b/Client/src/components/friendsPage/tabs/SuggestedFriends.jsx
@@ -48,7 +48,7 @@ export default function SuggestedFriends() {
         />
       )}
 
-      <div className="flex flex-wrap gap-3 2xl:gap-4 mt-4">
+      <div className="flex flex-wrap justify-center gap-3 2xl:gap-4 mt-4">
         {filteredUsers.map((user) => (
           <UserCard key={user._id} user={user} selectedTab="suggested" />
         ))}

--- a/Client/src/components/skeletons/FriendsSkeletonLoader.jsx
+++ b/Client/src/components/skeletons/FriendsSkeletonLoader.jsx
@@ -1,19 +1,19 @@
 import React from "react";
 import UserCardSkeleton from "./UserCardSkeleton";
+import { Loader2Icon } from "lucide-react";
 
-const FriendsSkeletonLoader = ({ count = 9 }) => {
-  // Using 9 to create a full 3x3 grid
+const FriendsSkeletonLoader = ({ count = 12 }) => {
   return (
-    // --- UPDATED FOR 3-COLUMN LAYOUT ---
-    // We now use CSS Grid instead of Flexbox.
-    // - `grid-cols-1`: 1 column on mobile (default).
-    // - `md:grid-cols-2`: 2 columns on medium screens.
-    // - `lg:grid-cols-3`: 3 columns on large screens, which achieves your goal.
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {Array.from({ length: count }).map((_, index) => (
-        <UserCardSkeleton key={index} />
-      ))}
-    </div>
+    <>
+      <div className="flex flex-wrap justify-center gap-3 2xl:gap-4 mt-4">
+        {Array.from({ length: count }).map((_, index) => (
+          <UserCardSkeleton key={index} />
+        ))}
+      </div>
+      <div className="mx-auto w-fit">
+        <Loader2Icon size={50} className="mt-10 animate-spin text-[var(--bg-sec)]" />
+      </div>
+    </>
   );
 };
 

--- a/Client/src/components/skeletons/UserCardSkeleton.jsx
+++ b/Client/src/components/skeletons/UserCardSkeleton.jsx
@@ -2,16 +2,13 @@ import React from "react";
 
 const UserCardSkeleton = () => {
   return (
-    // --- UPDATED FOR GRID LAYOUT ---
-    // Removed width constraints like `sm:max-w-[220px]` and `flex-grow`.
-    // `w-full` ensures the card perfectly fills the grid column defined by the parent.
+
     <div
-      className="w-full p-4 border rounded-[var(--radius)] 
-                 bg-[var(--bg-sec)] border-[var(--bg-ter)]"
+      className="flex-1 basis-[250px] max-w-sm p-3 rounded-3xl pt-4 bg-[var(--bg-sec)]"
     >
       <div className="animate-pulse flex flex-col items-center text-center">
         {/* Avatar Placeholder */}
-        <div className="w-16 h-16 rounded-full mb-3 bg-[var(--bg-primary)]"></div>
+        <div className="w-24 h-24 rounded-full mb-3 bg-[var(--bg-primary)]"></div>
 
         {/* Name Placeholder */}
         <div className="h-4 w-3/4 rounded mb-2 bg-[var(--bg-primary)]"></div>
@@ -20,7 +17,7 @@ const UserCardSkeleton = () => {
         <div className="h-3 w-1/2 rounded mb-4 bg-[var(--bg-primary)]"></div>
 
         {/* Button Placeholder */}
-        <div className="h-9 w-full rounded-md mt-2 bg-[var(--bg-primary)]"></div>
+        <div className="h-10 w-full rounded-lg mt-2 bg-[var(--bg-primary)]"></div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
This PR standardizes the layout across all tabs in the Friends page. The Suggested tab was used as the base design. Skeletons, card spacing, and alignment have been matched across Friend Requests, Sent Requests, and All Friends tabs. 

## Related Issue
FIX: UI in friend's page. and skeleton. #657 

## Changes Made
<!-- List the changes made in this PR. -->
- Updated skeleton layout (removed borders, matched rows/columns with Suggested tab)
- Applied the Suggested tab layout to all Friends page tabs
- Added loader at the end
- Minor margin and spacing adjustments for visual consistency

## Screenshots
### Before
<img width="1917" height="971" alt="before" src="https://github.com/user-attachments/assets/643f7bab-f622-410c-a85d-9ba6274b954b" />

### After
<img width="1918" height="971" alt="1400p ss" src="https://github.com/user-attachments/assets/68a1d64b-db9d-4b59-939e-4e2f384b4643" />

<img width="1918" height="970" alt="mobile ss" src="https://github.com/user-attachments/assets/bf16fa7a-75de-4a89-84a8-b86ffc022ed2" />

## Checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached.
- [x] No breaking changes are introduced to existing functionality.
