### PR TITLE
Fix: remove logo hover effect from about page

### DIFF
--- a/Client/src/components/about/Hero.jsx
+++ b/Client/src/components/about/Hero.jsx
@@ -49,7 +49,7 @@ function Hero({ url, isLoading, stars, forks }) {
 
   return (
     <div className="relative h-[calc(100vh-110px)] flex flex-col items-start justify-center pb-12">
-      <div className="hover:bg-ter rounded-lg transition-opacity duration-300 size-28 md:size-32">
+      <div className="size-28 md:size-32">
         <img
           src="./Logo.svg"
           alt="Logo"


### PR DESCRIPTION
## Description
This PR removes the logo hover effect and the border radius

## Related Issue
Fixes #750 

## Changes Made
- Remove the border radius and hover effect from the logo

## Screenshots or GIFs (if applicable)
Before
<img width="185" height="204" alt="image" src="https://github.com/user-attachments/assets/01d49029-0cb0-4eb1-9dfa-48418f2a0062" />

After
<img width="377" height="223" alt="image" src="https://github.com/user-attachments/assets/2a41d0d6-bc86-4297-8f80-10713645009a" />


## checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.

