### PR TITLE
Update README.md with crct discord links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -52,7 +52,7 @@ Project maintainers are responsible for clarifying the standards of acceptable b
 
 If you are experiencing or witness any unacceptable behavior, or have other concerns, please reach out privately to the maintainers via:
 
-- 🗨️ Discord: [Join and message moderators](https://discord.gg/r55948xy)
+- 🗨️ Discord: [Join and message moderators](https://discord.gg/uZv6ShY345)
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/LEARN.md
+++ b/LEARN.md
@@ -217,7 +217,7 @@ Fixes #<issue-number>
 | What if I can't complete an issue? | Leave a comment, and it will be reassigned. |
 | What if my PR is rejected? | Read feedback, revise, and resubmit. |
 | Can beginners contribute? | Absolutely! Start with docs or simple issues. |
-| Where do I ask for help? | [EduHaven Discord](https://discord.gg/r55948xy) or in GitHub issues. |
+| Where do I ask for help? | [EduHaven Discord](https://discord.gg/uZv6ShY345) or in GitHub issues. |
 
 ---
 
@@ -232,7 +232,7 @@ Fixes #<issue-number>
 ---
 
 > 💬 **Still have questions?**
-> - Join our [Discord Community](https://discord.gg/r55948xy)
+> - Join our [Discord Community](https://discord.gg/uZv6ShY345)
 > - Open an issue with your doubt
 > - Or reach out to mentors during contribution events like GSSoC’25
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![join our group on discord](./Client/public/joinDiscordIcon.png)
-](https://discord.gg/CbsNFUDC)
+](https://discord.gg/uZv6ShY345) 
 
 <p align="center">
   <b>This project is now OFFICIALLY accepted for:</b>
@@ -105,7 +105,7 @@
 
 ## Installation and Setup
 
-- Make sure you've joined our [discord server](https://discord.gg/CbsNFUDC) so you can connect in case you face any issues.
+- Make sure you've joined our [discord server](https://discord.gg/uZv6ShY345) so you can connect in case you face any issues.
 - **Prerequisites:** Node.js, MongoDB, Git
 
 ### Steps to Run Locally
@@ -205,4 +205,4 @@ For full details, see [`KEEP_ALIVE.md`](KEEP_ALIVE.md).
 
 - Backend URL: https://eduhaven-backend.onrender.com/
 
-For any further queries, feel free to reach out on our [Discord](https://discord.gg/CbsNFUDC) group. Let’s make learning fun and productive!
+For any further queries, feel free to reach out on our [Discord](https://discord.gg/uZv6ShY345) group. Let’s make learning fun and productive!


### PR DESCRIPTION
## Description
I updated discord link at 3 places in the README.md file


## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #788 
## Changes Made
<!-- List the changes made in this PR. -->
- [x] I checked the README, and found 3 places where there is a discord link which is not working! 
<img width="706" height="557" alt="image" src="https://github.com/user-attachments/assets/69a9a0a1-c195-489b-8b07-2d5106cc56f6" />
<br> <br/>
Locations in README

1. The banner image at the top

2. The line under the installation/setup section
 
3. The note near the end (“For any further queries, feel free to reach out on our [Discord] group.”).

## Screenshots or GIFs (if applicable)
<img width="980" height="626" alt="image" src="https://github.com/user-attachments/assets/50a78c36-1ebe-401e-a391-8c8f24922192" />

And now its working fine...
## checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.

