### PR TITLE
Add active tab indicator and animation to NoteHeader and Notes page

### DIFF
--- a/Client/src/components/notes/NoteHeader.jsx
+++ b/Client/src/components/notes/NoteHeader.jsx
@@ -9,6 +9,7 @@ const NoteHeader = ({
   selectedNote,
   setStatus,
   setSelectedNote,
+  status, 
 }) => {
   return (
     <header
@@ -22,7 +23,12 @@ const NoteHeader = ({
       <div className="flex items-center gap-4">
         <Button
           variant="ghost"
-          className="flex items-center gap-2 font-medium text-[var(--txt)] hover:bg-[var(--bg-ter)] px-3 py-2 rounded-lg"
+          className={`flex items-center gap-2 font-medium px-3 py-2 rounded-lg relative
+            ${
+              status === "active"
+                ? "text-[var(--btn)] font-bold"
+                : "text-[var(--txt)] hover:bg-[var(--bg-ter)]"
+            }`}
           onClick={() => {
             setStatus("active");
             setSelectedNote(null);
@@ -30,10 +36,22 @@ const NoteHeader = ({
         >
           <FileText size={18} />
           Notes
+          {status === "active" && (
+            <motion.div
+              layoutId="activeTab"
+              className="absolute bottom-0 left-0 w-full h-[2px] bg-[var(--btn)] rounded"
+              transition={{ type: "spring", stiffness: 500, damping: 30 }}
+            />
+          )}
         </Button>
         <Button
           variant="ghost"
-          className="flex items-center gap-2 font-medium text-[var(--txt)] hover:bg-[var(--bg-ter)] px-3 py-2 rounded-lg"
+          className={`flex items-center gap-2 font-medium px-3 py-2 rounded-lg relative
+            ${
+              status === "archive"
+                ? "text-[var(--btn)] font-bold"
+                : "text-[var(--txt)] hover:bg-[var(--bg-ter)]"
+            }`}
           onClick={() => {
             setStatus("archive");
             setSelectedNote(null);
@@ -41,10 +59,22 @@ const NoteHeader = ({
         >
           <Archive size={18} />
           Archived
+          {status === "archive" && (
+            <motion.div
+              layoutId="activeTab"
+              className="absolute bottom-0 left-0 w-full h-[2px] bg-[var(--btn)] rounded"
+              transition={{ type: "spring", stiffness: 500, damping: 30 }}
+            />
+          )}
         </Button>
         <Button
           variant="ghost"
-          className="flex items-center gap-2 font-medium text-[var(--txt)] hover:bg-[var(--bg-ter)] px-3 py-2 rounded-lg"
+          className={`flex items-center gap-2 font-medium px-3 py-2 rounded-lg relative
+            ${
+              status === "trash"
+                ? "text-[var(--btn)] font-bold"
+                : "text-[var(--txt)] hover:bg-[var(--bg-ter)]"
+            }`}
           onClick={() => {
             setStatus("trash");
             setSelectedNote(null);
@@ -52,6 +82,13 @@ const NoteHeader = ({
         >
           <Trash2 size={18} />
           Trash
+          {status === "trash" && (
+            <motion.div
+              layoutId="activeTab"
+              className="absolute bottom-0 left-0 w-full h-[2px] bg-[var(--btn)] rounded"
+              transition={{ type: "spring", stiffness: 500, damping: 30 }}
+            />
+          )}
         </Button>
       </div>
 

--- a/Client/src/pages/Notes.jsx
+++ b/Client/src/pages/Notes.jsx
@@ -402,6 +402,7 @@ const Notes = () => {
             setSearchTerm={setSearchTerm}
             setStatus={setStatus}
             setSelectedNote={setSelectedNote}
+            status={status}
           />
 
           {(status == "active" || status == "archive") && (


### PR DESCRIPTION
## Description
This PR adds an active tab indicator and animation for the Notes page, specifically improving the user interface for navigating between "Notes", "Archived", and "Trash" tabs. This enhances clarity and user experience while switching tabs.

Fixes #774

## Changes Made
<!-- List the changes made in this PR. -->
- [x] Updated ...
- [x] Added ...

- before
<img width="436" height="131" alt="image" src="https://github.com/user-attachments/assets/09b7033f-12cb-40f0-afc0-0dd41f981b70" />
- after
<img width="1367" height="490" alt="image" src="https://github.com/user-attachments/assets/dff90455-17c6-44f1-880e-c38ac048e133" />

## checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.
