### PR TITLE
Implemented full screen in notes card in home page

### DIFF
--- a/Client/src/App.jsx
+++ b/Client/src/App.jsx
@@ -47,6 +47,7 @@ function App() {
                 />
                 <Route path="games/*" element={<GameRoom />} />
                 <Route path="notes" element={<Notes />} />
+                <Route path="notes/:noteId" element={<Notes />} />
                 <Route path="about" element={<About />} />
                 <Route path="settings/" element={<Settings />} />
                 <Route path="friends" element={<FriendsPage />} />

--- a/Client/src/components/home/notes/BottomControls.jsx
+++ b/Client/src/components/home/notes/BottomControls.jsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import {
   Trash,
   Palette,
@@ -10,6 +11,7 @@ import {
 import { Button } from "@/components/ui/button";
 
 function BottomControls({ isSynced, rotate, notes, currentPage, onDelete }) {
+  const navigate = useNavigate();
   return (
     <div className="flex justify-between items-center w-full px-3 p-2 absolute bottom-0 left-0 group-hover:bg-gradient-to-t from-[var(--bg-sec)] via-[var(--bg-sec)] to-transparent">
       <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -42,7 +44,7 @@ function BottomControls({ isSynced, rotate, notes, currentPage, onDelete }) {
         </Button>
         <Button
           title="Open in full screen"
-          onClick={() => console.log("clicked maximize")}
+          onClick={() => navigate(`/notes/${notes[currentPage]?._id || "new"}`)}
           variant="transparent"
           size="icon"
           className=" hover:bg-[var(--bg-ter)] rounded-full"

--- a/Client/src/components/notes/NoteEditor.jsx
+++ b/Client/src/components/notes/NoteEditor.jsx
@@ -29,6 +29,7 @@ const NoteEditor = ({
   insertLink,
   insertImage,
   insertTable,
+  onClose,
 }) => {
   return (
     <motion.div
@@ -60,7 +61,7 @@ const NoteEditor = ({
           />
 
           <button
-            onClick={() => setSelectedNote(null)}
+            onClick={onClose}
             className="p-2 border-none bg-transparent cursor-pointer"
             style={{
               color: "var(--txt-dim)",

--- a/Client/src/pages/Notes.jsx
+++ b/Client/src/pages/Notes.jsx
@@ -1,3 +1,4 @@
+import { useNavigate, useParams } from "react-router-dom";
 import FileHandler from "@tiptap/extension-file-handler";
 import Highlight from "@tiptap/extension-highlight";
 import { Image } from "@tiptap/extension-image";
@@ -49,6 +50,9 @@ const colors = [
 ];
 
 const Notes = () => {
+  const { noteId } = useParams();
+  const navigate = useNavigate();
+  const isFullScreen = !!noteId;
   const { data: notes = [], isLoading } = useNotes();
   const { data: archiveNotes = [], isLoading: isArchiveLoading } =
     useArchivedNotes();
@@ -66,6 +70,15 @@ const Notes = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedNote, setSelectedNote] = useState(null);
   const [showColorPicker, setShowColorPicker] = useState(null);
+
+  useEffect(() => {
+    if (noteId && notes.length > 0) {
+      const foundNote = notes.find((n) => n._id === noteId);
+      if (foundNote) {
+        setSelectedNote(foundNote);
+      }
+    }
+  }, [noteId, notes]);
 
   const notesObj = {
     active: notes,
@@ -393,7 +406,9 @@ const Notes = () => {
       <div className="flex h-screen">
         {/* notes page (also works as sidebar} */}
         <div
-          className={`${selectedNote ? "w-80" : "w-full"} overflow-auto p-4`}
+          className={`${
+            isFullScreen ? "hidden" : selectedNote ? "w-80" : "w-full"
+          } overflow-auto p-4`}
         >
           <NoteHeader
             selectedNote={selectedNote}
@@ -435,16 +450,22 @@ const Notes = () => {
 
         {/* Note Editor */}
         {selectedNote && (
-          <NoteEditor
-            selectedNote={selectedNote}
-            setSelectedNote={setSelectedNote}
-            colors={colors}
-            editor={editor}
-            updateNote={updateNote}
-            insertLink={insertLink}
-            insertImage={insertImage}
-            insertTable={insertTable}
-          />
+          <div className="flex-1 flex flex-col">
+            <NoteEditor
+              selectedNote={selectedNote}
+              setSelectedNote={setSelectedNote}
+              colors={colors}
+              editor={editor}
+              updateNote={updateNote}
+              insertLink={insertLink}
+              insertImage={insertImage}
+              insertTable={insertTable}
+              onClose={() => {
+                if (noteId) navigate(-1);
+                else setSelectedNote(null);
+              }}
+            />
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Description
This PR implements full screen feature in notes card in home page

## Related Issue
Fixes #773 

## Changes Made
- [ ] Added support for opening a note in full-screen NoteEditor when the full-screen icon is clicked on a note card in the Home page.
- [ ] Introduced a dynamic route (/notes/:noteId) to directly load the selected note.

## Screenshots or GIFs (if applicable)
https://github.com/user-attachments/assets/9557e880-9f21-41e9-9053-9f1b6823ebb8

## checklist

- [x ] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [ x] Only the necessary files are modified; no unrelated changes are included.
- [ x] Follows clean code principles (readable, maintainable, minimal duplication).
- [ x] All changes are clearly documented.
- [ x] Code has been tested across all supported themes and verified against potential edge cases.
- [ x] Multiple screenshots or recordings are attached (if required).
- [ x] No breaking changes are introduced to existing functionality.

## Additional Notes
<!-- Add any other relevant information or context. -->
