### PR TITLE
fix insert image button and handle Cloudinary image removal

### DIFF
--- a/Client/src/pages/Notes.jsx
+++ b/Client/src/pages/Notes.jsx
@@ -2,6 +2,7 @@ import FileHandler from "@tiptap/extension-file-handler";
 import Highlight from "@tiptap/extension-highlight";
 import { Image } from "@tiptap/extension-image";
 import Link from "@tiptap/extension-link";
+import { Extension } from "@tiptap/core";
 import Placeholder from "@tiptap/extension-placeholder";
 import { Table } from "@tiptap/extension-table";
 import TableCell from "@tiptap/extension-table-cell";
@@ -75,6 +76,94 @@ const Notes = () => {
 
   const typingTimeoutRef = useRef(null);
 
+  const BackspaceOnImage = Extension.create({
+  addKeyboardShortcuts() {
+    return {
+      Backspace: ({ editor }) => {
+        const { state } = editor;
+        const { $from, empty } = state.selection;
+        if (!empty) {
+          return false;
+        }     
+
+        let imageNode = null;
+        let imagePos = null;
+
+        if ($from.nodeBefore && $from.nodeBefore.type.name === "image") {
+          imageNode = $from.nodeBefore;
+          imagePos = $from.pos - $from.nodeBefore.nodeSize;
+         
+        }
+         else if ($from.parentOffset === 0) {
+          const prevNode = state.doc.resolve($from.pos - 1);
+          if (prevNode.nodeBefore && prevNode.nodeBefore.type.name === "image") {
+            imageNode = prevNode.nodeBefore;
+            imagePos = prevNode.pos - prevNode.nodeBefore.nodeSize;
+           
+          }
+        }
+         else {
+          for (let pos = $from.pos - 1; pos >= 0; pos--) {
+            try {
+              const resolvedPos = state.doc.resolve(pos);
+              const node = resolvedPos.nodeAfter;
+              if (node && node.type.name === "image") {
+                imageNode = node;
+                imagePos = pos;
+               
+                break;
+              }
+        
+              if (node && node.type.name !== "text") {
+                break;
+              }
+            } catch (e) {
+              break;
+            }
+          }
+        }
+
+        if (imageNode) {
+         
+          mySpecialImageHandler(imageNode, imagePos, editor);
+         
+          return true;
+        }
+
+       
+        return false; 
+      },
+    };
+  },
+});
+
+async function mySpecialImageHandler(node, pos, editor) {
+
+  
+  try {
+
+    const src = node.attrs.src;
+    if (!src) {
+      console.error("No src attribute found on image");
+      return;
+    }
+    
+    const publicId = src.split("/").pop().split(".")[0];
+    
+    
+    await axiosInstance.post("/note/deleteimage", { publicId });
+    if (pos !== null && pos >= 0) {
+      const tr = editor.state.tr.delete(pos, pos + node.nodeSize);
+      editor.view.dispatch(tr);
+    }
+    
+  } catch (err) {
+    console.error("Image deletion failed:", err);
+  }
+}
+
+
+
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -105,6 +194,7 @@ const Notes = () => {
       Image.configure({
         allowBase64: true,
       }),
+      BackspaceOnImage,
       FileHandler.configure({
         allowedMimeTypes: [
           "image/png",
@@ -319,12 +409,32 @@ const Notes = () => {
     URL.revokeObjectURL(url);
   };
 
-  const insertImage = () => {
-    const url = prompt("Enter image URL:");
-    if (url && editor) {
-      editor.chain().focus().setImage({ src: url }).run();
+ const insertImage = () => {
+  if (!editor) return;
+
+  // Create hidden input
+  const input = document.createElement("input");
+  input.type = "file";
+  input.accept = "image/*";
+  input.multiple = true;
+
+  // Attach change event
+  input.addEventListener("change", async () => {
+    const files = input?.files;
+    console.log(files);
+    if (!files || files.length === 0) return;
+
+    try {
+      await handleImageUpload(editor, files, editor.state.selection.from); // your upload function
+
+    } catch (err) {
+      console.error("Image upload failed:", err);
     }
-  };
+  });
+
+  // Must be triggered synchronously from user click
+  input.click();
+};
 
   const insertLink = () => {
     const url = prompt("Enter URL:");

--- a/Server/Controller/NotesController.js
+++ b/Server/Controller/NotesController.js
@@ -1,5 +1,6 @@
 import Note from "../Model/NoteModel.js";
 import { v2 as cloudinary } from "cloudinary";
+import { removefromCloudinary } from "../utils/Cloudnary.js";
 
 // Configure Cloudinary
 cloudinary.config({
@@ -291,3 +292,25 @@ export const restoreNote = async (req, res) => {
     res.status(500).json({ success: false, error: error.message });
   }
 };
+export const deleteNoteImage = async (req, res) => {
+  try {
+    if (!req.user) {
+      return res.status(401).json({ error: "Please log in" });
+    }
+    const { publicId } = req.body;
+    if (!publicId) {
+      return res.status(400).json({ error: "No image specified" });
+    }
+    await removefromCloudinary(publicId, "image");
+    return res
+      .status(200)
+      .json({ message: "Note image deleted successfully" });
+  } catch (error) {
+    console.error("Note image deletion error:", error);
+    return res.status(500).json({
+      error: "Failed to delete note image",
+      details: error.message,
+    });
+  }
+};
+

--- a/Server/Routes/NotesRoutes.js
+++ b/Server/Routes/NotesRoutes.js
@@ -6,6 +6,7 @@ import {
   archiveNote,
   createNote,
   deleteNote,
+  deleteNoteImage,
   getAllNotes,
   getArchivedNotes,
   getNoteById,
@@ -107,5 +108,6 @@ router.put(
 );
 
 router.delete("/:id", authMiddleware, deleteNote);
+router.post("/deleteimage", authMiddleware, deleteNoteImage);
 
 export default router;

--- a/Server/utils/Cloudnary.js
+++ b/Server/utils/Cloudnary.js
@@ -64,5 +64,13 @@ const cloudinaryUpload = async (req, res, next) => {
     });
   }
 };
+const removefromCloudinary=async(publicid,resource_type)=>{        
+      try {         
+        await cloudinary.uploader.destroy("eduhaven-notes/"+publicid,{resource_type:resource_type})
+      } catch (error) {
+        throw ApiError(500,{},"Error in deleting the cloudeinary file")
+      }
+    }
 
-export { uploadmanish, cloudinaryUpload };
+export { uploadmanish, cloudinaryUpload, removefromCloudinary };
+


### PR DESCRIPTION
### PR Title  
This PR improves image handling in the note editor  and removal workflow

---

### Related Issue  
Fixes #725  

---

### Changes Made  
- Replaced the old "Insert Image" button (which required a URL) with a **file selector** that supports uploading multiple images at once.  
- Fixed behavior where adding multiple images would **replace the previous one** — now multiple images are appended correctly.  
- Fixed image deletion: removing an image from a note now also **removes it from Cloudinary**, ensuring user privacy and freeing storage.  

---

### Screenshots or GIFs (if applicable)  
_Add screenshots or a short recording of insert/remove behavior here_  

---

### Checklist  
- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.  
- [x] Only the necessary files are modified; no unrelated changes are included.  
- [x] Follows clean code principles (readable, maintainable, minimal duplication).  
- [x] All changes are clearly documented.  
- [x] Code has been tested across all supported themes and verified against potential edge cases.  
- [x] Screenshots/recordings attached (if required).  
- [x] No breaking changes are introduced to existing functionality.  
