### PR TITLE
Fix: sender name in mails

### DIFF
--- a/Server/utils/sendMail.js
+++ b/Server/utils/sendMail.js
@@ -34,7 +34,7 @@ const sendEmail = async (Email, FirstName, otp, emailType) => {
     const content = emailContent[emailType] || emailContent.signup;
 
     const response = await resend.emails.send({
-      from: "Eduahaven <noreply@eduhaven.online>",
+      from: "Eduhaven <noreply@eduhaven.online>",
       to: Email,
       subject: content.subject,
       html: `


### PR DESCRIPTION
## Description
Sender name in mails received by users were appearing as "Eduahaven". Fixed it to be "Eduhaven".

## Related Issue
Fixes #762 

## Changes Made
Updated sendMail.js
- Renamed Eduahaven as Eduhaven

