### PR TITLE
Make email clickable with hover effect on Privacy page

### DIFF
--- a/Client/src/pages/PrivacyPolicy.jsx
+++ b/Client/src/pages/PrivacyPolicy.jsx
@@ -574,7 +574,7 @@ export default function PrivacyPolicy() {
                     hesitate to reach out.
                   </p>
                   <div
-                    className="inline-flex items-center px-4 sm:px-6 py-3 rounded-xl border shadow-sm"
+                    className="inline-flex items-center px-4 sm:px-6 py-3 rounded-xl border shadow-sm transition-colors duration-200 hover:opacity-80"
                     style={{
                       backgroundColor: "var(--bg-ter)",
                       borderColor: "var(--bg-primary)",
@@ -593,7 +593,13 @@ export default function PrivacyPolicy() {
                       className="text-base sm:text-lg font-semibold"
                       style={{ color: "var(--txt)" }}
                     >
-                      rishucodingdrive@gmail.com
+                      <a
+                        href="https://mail.google.com/mail/?view=cm&fs=1&to=rishucodingdrive@gmail.com"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        rishucodingdrive@gmail.com
+                      </a>
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
## Description
Made the email a clickable link from a simple plain text, which on clicking will take to gmail with pre defined mail address in recipient field.

## Related Issue
Fixes #804 

## Changes Made
In PrivacyPolicy.jsx
Surrounded the email address with anchor tag and made it a hyperlink which would open in a new tab. Also added hover effect on the button.

## Screenshots or GIFs (if applicable)
https://github.com/user-attachments/assets/20fde8c8-d5df-4519-95cc-de101140a6b0



