### PR TITLE
Display user's profile in leaderboard

### DIFF
--- a/Client/src/components/stats/Leaderboard.jsx
+++ b/Client/src/components/stats/Leaderboard.jsx
@@ -14,6 +14,7 @@ const Leaderboard = () => {
   const [view, setView] = useState("weekly");
   const [friendsOnly, setFriendsOnly] = useState(false);
   const [currentUserId, setCurrentUserId] = useState(null);
+  const [imageErrorIds, setImageErrorIds] = useState(new Set());
 
   // Replace direct axios call with TanStack Query hook
   const { data: leaderboard = [], isLoading } = useLeaderboard(
@@ -170,9 +171,27 @@ const Leaderboard = () => {
                   </div>
                   <Link
                     to={isCurrentUser ? "/stats" : `/user/${user.userId}`}
-                    className="text-center font-semibold"
+                    className="text-center font-semibold flex items-center gap-2"
                   >
-                    {user.username}
+                    {/* Show user's profile picture before their name. If the image fails, track the userId in imageErrorIds so we don't retry rendering a broken image. */}
+                    {user.profilePicture && !imageErrorIds.has(user.userId) ? (
+                      <img
+                        src={user.profilePicture}
+                        alt={`${user.username}'s avatar`}
+                        className="w-7 h-7 rounded-full object-cover flex-shrink-0"
+                        referrerPolicy="no-referrer"
+                        onError={() => {
+                          setImageErrorIds((prev) => {
+                            const next = new Set(prev);
+                            next.add(user.userId);
+                            return next;
+                          });
+                        }}
+                      />
+                    ) : null}
+                    <span className="truncate max-w-[12rem] 2xl:max-w-[9.5rem] inline-block align-middle">
+                      {user.username}
+                    </span>
                   </Link>
                 </div>
 

--- a/Server/Controller/StudySessionController.js
+++ b/Server/Controller/StudySessionController.js
@@ -232,6 +232,7 @@ const getLeaderboardData = async (period, friendsOnly, userId) => {
         _id: 0,
         userId: "$user._id",
         username: "$user.FirstName",
+        profilePicture: "$user.ProfilePicture",
         totalDuration: 1,
       },
     },


### PR DESCRIPTION
## Description
This PR enhances the leaderboard by displaying each user’s profile image alongside their name.

## Related Issue
[FEATURE] Show user's profile in leaderboard. #742

## Changes Made
- [x] Updated leaderboard UI to display user profile image.  
- [x] Added `profilePicture` to leaderboard aggregation pipeline output.  
- [x] Implemented safe image fallback handling in frontend (`onError`). 

## Screenshot
<img width="1918" height="970" alt="web ss" src="https://github.com/user-attachments/assets/f627af63-a321-41a4-910c-4c8b9b8381e6" />

## Checklist

- [x]  Code is formatted with Prettier.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Clean and readable code with minimal duplication.
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] No breaking changes are introduced to existing functionality.

## Additional Notes

If a user’s profile image fails to load, the `userId` is added to `imageErrorIds` so React does not retry rendering the broken image on subsequent re-renders. This prevents UI flicker or broken image icons. No fallback image is displayed, only the username is shown in such cases.
