### PR TITLE
Fix: Prevent server crash when Email field is missing in user documents

### DIFF
--- a/Server/Middlewares/usernameHandler.js
+++ b/Server/Middlewares/usernameHandler.js
@@ -31,6 +31,12 @@ export async function handleMissingUsernames() {
   });
 
   for (const user of usersWithoutUsername) {
+    // 🔒 Guard: skip if Email missing/invalid
+    if (!user.Email || typeof user.Email !== "string" || !user.Email.includes("@")) {
+      console.warn(`⚠️ Skipping user ${user._id}: invalid or missing Email`);
+      continue;
+    }
+
     const base = user.Email.split("@")[0];
 
     let updated = false;
@@ -42,18 +48,17 @@ export async function handleMissingUsernames() {
         await user.save();
         console.log(`✅ Updated ${user.Email} → ${newUsername}`);
         updated = true;
-        break; 
+        break;
       } catch (err) {
         if (err.code === 11000) {
           continue; // try again
         }
-        throw err; 
+        throw err;
       }
     }
 
     if (!updated) {
-      console.error(`Failed to assign username after retries`);
+      console.error(`❌ Failed to assign username after retries for ${user.Email || user._id}`);
     }
   }
 }
-

--- a/Server/index.js
+++ b/Server/index.js
@@ -1,7 +1,7 @@
+import dotenv from "dotenv";
 import express from "express";
 import { createServer } from "http";
 import fetch, { Headers, Request, Response } from "node-fetch";
-import dotenv from "dotenv";
 import { applyCommonMiddleware } from "./Middlewares/commonMiddleware.js";
 import { ConnectDB } from "./Database/Db.js";
 import { mountRoutes } from "./Routes/Routes.js";


### PR DESCRIPTION
## Description
This PR fixes a critical server crash issue caused by the `handleMissingUsernames` middleware.  
Previously, the server attempted to call `.split()` on `user.Email` without verifying its existence.  
If a user document was missing the `Email` field, this resulted in a `TypeError` during startup, preventing the server from running.  

The fix adds proper guard checks to ensure `Email` exists and is valid before calling `.split()`.  
If the field is missing, the user is safely skipped with a warning log instead of crashing the server.  

## Related Issue
Fixes #834 

## Changes Made
- [x] Added guard condition in `handleMissingUsernames` to check `user.Email` validity before `.split()`.
- [x] Skips users with missing/invalid emails and logs a warning.
- [x] Prevents server crash on startup due to malformed user documents.

## Screenshot:
update workflow would look like:
<img width="868" height="189" alt="image" src="https://github.com/user-attachments/assets/865a88ab-7e68-497e-8424-ac70650a6585" />


## checklist
- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested against potential edge cases (missing/null/invalid `Email`).
- [x] No breaking changes are introduced to existing functionality.

## Additional Notes
This fix ensures that server startup is robust even if old or malformed user records exist in the database.  
It improves stability without altering the normal username assignment logic.  
