### PR TITLE
add download functionality to home notes tab

### DIFF
--- a/Client/src/components/home/notes/BottomControls.jsx
+++ b/Client/src/components/home/notes/BottomControls.jsx
@@ -10,6 +10,22 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
+const exportNote = (note) => {
+  console.log("clicked download")
+  const tempDiv = document.createElement("div");
+  tempDiv.innerHTML = note.content;
+  const textContent = tempDiv.textContent || tempDiv.innerText || "";
+  const content = `# ${note.title}\n\n${textContent}`;
+
+  const blob = new Blob([content], { type: "text/markdown" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${note.title || "note"}.md`;
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
 function BottomControls({ isSynced, rotate, notes, currentPage, onDelete }) {
   const navigate = useNavigate();
   return (
@@ -26,7 +42,7 @@ function BottomControls({ isSynced, rotate, notes, currentPage, onDelete }) {
         </Button>
         <Button
           title="Download note"
-          onClick={() => console.log("clicked download")}
+          onClick={() => exportNote(notes[currentPage])}
           variant="transparent"
           size="icon"
           className=" hover:bg-[var(--bg-ter)] rounded-full"
@@ -88,11 +104,11 @@ function BottomControls({ isSynced, rotate, notes, currentPage, onDelete }) {
       <div className="bg-[var(--bg-sec)] txt-disabled p-1 px-2 rounded-full">
         {notes[currentPage]?.createdAt
           ? new Date(notes[currentPage].createdAt).toLocaleDateString() +
-            "\u00A0\u00A0\u00A0" +
-            new Date(notes[currentPage].createdAt).toLocaleTimeString([], {
-              hour: "2-digit",
-              minute: "2-digit",
-            })
+          "\u00A0\u00A0\u00A0" +
+          new Date(notes[currentPage].createdAt).toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          })
           : "No date available"}
       </div>
     </div>


### PR DESCRIPTION
## Description
The download button on home page for notes did not work. So i added functionality to download those notes in md files. 

## Related Issue
Fixes #775 

## Changes Made
-  Updated `Client/src/components/home/notes/BottomControls.jsx`

## Screenshots or GIFs (if applicable)
[Demo Video](https://jumpshare.com/s/Wod75F1ugpAI4RJgBswN)

## checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.

