### PR TITLE
Fix/Framer Motion Stacking Context Issue from PinnedLinks Dropdown Menu

### DIFF
--- a/Client/src/components/home/navBar/PinnedLinks.jsx
+++ b/Client/src/components/home/navBar/PinnedLinks.jsx
@@ -398,7 +398,7 @@ function PinnedLinks() {
               onClick={handleAddNew}
               variant="default"
               size="default"
-              className="block w-full px-4 py-2 txt hover:bg-ter rounded-md mt-2 flex items-center gap-2 transition-colors duration-200 border-t border-opacity-20 border-gray-300 pt-3"
+              className="w-full px-4 py-2 txt hover:bg-ter rounded-md mt-2 flex items-center gap-2 transition-colors duration-200 border-t border-opacity-20 border-gray-300 pt-3"
             >
               <motion.div
                 initial={{ rotate: -90, scale: 0.8 }}

--- a/Client/src/components/home/navBar/PinnedLinks.jsx
+++ b/Client/src/components/home/navBar/PinnedLinks.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from "react";
 import { ExternalLink, Plus, X, MoreVertical } from "lucide-react";
-import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 
 // Helper to get domain from a URL
@@ -236,307 +235,177 @@ function PinnedLinks() {
       {/* Dropdown of existing pinned links + add button */}
       {/* <AnimatePresence mode="wait"> */}
       {showDropdown && (
-        <motion.div
-          initial={{
-            opacity: 0,
-            height: 0,
-            scale: 0.95,
-            y: -8,
-          }}
-          animate={{
-            opacity: 1,
-            height: "auto",
-            scale: 1,
-            y: 0,
-          }}
-          exit={{
-            opacity: 0,
-            height: 0,
-            scale: 0.95,
-            y: -8,
-          }}
-          transition={{
-            duration: 0.15,
-            ease: [0.25, 0.1, 0.25, 1],
-            // height: { duration: 0.35 },
-            // opacity: { duration: 0.25 },
-            // scale: { duration: 0.3 },
-            // y: { duration: 0.3 },
-          }}
+        <div
           ref={dropdownRef}
-          className="absolute top-full left-0 mt-2 bg-sec shadow-lg rounded-lg p-2 z-10 min-w-[17rem] overflow-hidden backdrop-blur-sm border border-opacity-20 border-gray-300"
-          style={{
-            boxShadow:
-              "0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
-          }}
+          className="absolute top-full left-0 mt-2 bg-sec shadow-lg rounded-lg p-2 z-10 min-w-[17rem] overflow-hidden backdrop-blur-sm border border-opacity-20 border-gray-300
+          transition-all duration-200 ease-out transform origin-top
+          opacity-100 scale-100"
         >
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 0.1, duration: 0.3 }}
-          >
-            {pinnedLinks.map((item, index) => (
-              <motion.div
-                key={item.id}
-                initial={{
-                  opacity: 0,
-                  x: -20,
-                  filter: "blur(4px)",
-                }}
-                animate={{
-                  opacity: 1,
-                  x: 0,
-                  filter: "blur(0px)",
-                }}
-                transition={{
-                  delay: index * 0.05,
-                  duration: 0.2,
-                  ease: [0.15, 0.05, 0.15, 1],
-                }}
-                whileHover={{ scale: 1.02 }}
-                className="flex items-center justify-between px-4 py-2 txt hover:bg-ter rounded-md transition-colors duration-200"
+          {pinnedLinks.map((item) => (
+            <div
+              key={item.id}
+              className="flex items-center justify-between px-4 py-2 txt hover:bg-ter rounded-md transition-colors duration-200"
+            >
+              <div
+                className="flex items-center gap-2 cursor-pointer flex-1"
+                onClick={() => openWorkspace(item.links)}
               >
-                <motion.div
-                  className="flex items-center gap-2 cursor-pointer flex-1"
-                  onClick={() => openWorkspace(item.links)}
-                  whileTap={{ scale: 0.98 }}
-                >
-                  <motion.div
-                    className="flex items-center gap-1"
-                    initial={{ scale: 0.8 }}
-                    animate={{ scale: 1 }}
-                    transition={{ delay: index * 0.05, duration: 0.2 }}
-                  >
-                    {item.links.map((link, idx) => (
-                      <motion.img
-                        key={idx}
-                        src={getFaviconUrl(link)}
-                        alt="icon"
-                        className="w-4 h-4 rounded-sm"
-                        initial={{ opacity: 0, rotate: -90 }}
-                        animate={{ opacity: 1, rotate: 0 }}
-                        transition={{
-                          delay: index * 0.05 + idx * 0.02,
-                          duration: 0.4,
-                        }}
-                        onError={(e) => {
-                          e.target.style.display = "none";
-                        }}
-                      />
-                    ))}
-                  </motion.div>
-                  <motion.span
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    transition={{ delay: index * 0.05, duration: 0.3 }}
-                  >
-                    {item.title}
-                  </motion.span>
-                </motion.div>
-
-                <div className="relative">
-                  <Button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setOpenMenuId(openMenuId === item.id ? null : item.id);
-                    }}
-                    variant="transparent"
-                    size="icon"
-                    className="p-1 rounded hover:bg-ter transition-colors duration-200"
-                  >
-                    <MoreVertical className="w-4 h-4" />
-                  </Button>
-
-                  <AnimatePresence>
-                    {openMenuId === item.id && (
-                      <motion.div
-                        initial={{
-                          opacity: 0,
-                          scale: 0.9,
-                          y: -5,
-                        }}
-                        animate={{
-                          opacity: 1,
-                          scale: 1,
-                          y: 0,
-                        }}
-                        exit={{
-                          opacity: 0,
-                          scale: 0.9,
-                          y: -5,
-                        }}
-                        transition={{
-                          duration: 0.2,
-                          ease: [0.25, 0.46, 0.45, 0.94],
-                        }}
-                        className="absolute right-0 mt-1 bg-ter shadow-lg rounded-md p-1 z-10 min-w-[5rem] border border-opacity-10 border-gray-400"
-                      >
-                        <Button
-                          onClick={() => handleEditLink(item.id)}
-                          variant="secondary"
-                          size="default"
-                          className="block w-full text-left px-2 py-1 rounded-sm txt hover:bg-sec transition-colors duration-150"
-                        >
-                          Edit
-                        </Button>
-                        <Button
-                          onClick={() => handleDeleteLink(item.id)}
-                          variant="destructive"
-                          size="default"
-                          className="block w-full text-left px-2 py-1 rounded-sm txt hover:bg-sec transition-colors duration-150"
-                        >
-                          Delete
-                        </Button>
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
+                <div className="flex items-center gap-1">
+                  {item.links.map((link, idx) => (
+                    <img
+                      key={idx}
+                      src={getFaviconUrl(link)}
+                      alt="icon"
+                      className="w-4 h-4 rounded-sm"
+                      onError={(e) => (e.target.style.display = "none")}
+                    />
+                  ))}
                 </div>
-              </motion.div>
-            ))}
+                <span>{item.title}</span>
+              </div>
 
-            <Button
-              onClick={handleAddNew}
-              variant="default"
-              size="default"
-              className="w-full px-4 py-2 txt hover:bg-ter rounded-md mt-2 flex items-center gap-2 transition-colors duration-200 border-t border-opacity-20 border-gray-300 pt-3"
-            >
-              <motion.div
-                initial={{ rotate: -90, scale: 0.8 }}
-                animate={{ rotate: 0, scale: 1 }}
-                transition={{
-                  delay: 0.45 + pinnedLinks.length * 0.05,
-                  duration: 0.2,
-                }}
-              >
-                <Plus className="w-4 h-4" />
-              </motion.div>
-              <motion.span
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{
-                  delay: 0.2 + pinnedLinks.length * 0.05,
-                  duration: 0.2,
-                }}
-              >
-                Add Link
-              </motion.span>
-            </Button>
-          </motion.div>
-        </motion.div>
-      )}
-      {/* </AnimatePresence> */}
-
-      {/* Modal for adding/editing a workspace */}
-      {showModal && (
-        <AnimatePresence>
-          <motion.div
-            key="backdrop"
-            className="fixed inset-0 z-50 backdrop-blur-sm bg-black/40 flex items-center justify-center transition-colors"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-          >
-            <motion.div
-              key="modal"
-              initial={{ opacity: 0, scale: 0.95, y: 20 }}
-              animate={{ opacity: 1, scale: 1, y: 0 }}
-              exit={{ opacity: 0, scale: 0.95, y: 20 }}
-              transition={{ duration: 0.25, ease: "easeInOut" }}
-              className="bg-sec backdrop-blur-xl border border-white/20 p-6 rounded-2xl shadow-2xl max-w-sm w-full "
-            >
-              <div className="flex justify-between items-center mb-4">
-                <h2 className="text-xl font-bold txt">
-                  {editItemId ? "Edit link" : "Create a link"}
-                </h2>
+              <div className="relative">
                 <Button
-                  onClick={() => {
-                    setShowModal(false);
-                    setEditItemId(null);
-                    setTitle("");
-                    setMainLink("");
-                    setExtraLinks([]);
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setOpenMenuId(openMenuId === item.id ? null : item.id);
                   }}
                   variant="transparent"
                   size="icon"
-                  className="p-1 hover:bg-ter rounded"
+                  className="p-1 rounded hover:bg-ter transition-colors duration-200"
                 >
-                  <X className="w-5 h-5 txt" />
+                  <MoreVertical className="w-4 h-4" />
                 </Button>
+
+                {openMenuId === item.id && (
+                  <div
+                    className="absolute right-0 mt-1 bg-ter shadow-lg rounded-md p-1 z-10 min-w-[5rem] border border-opacity-10 border-gray-400
+                    transition-all duration-200 transform origin-top opacity-100 scale-100"
+                  >
+                    <Button
+                      onClick={() => handleEditLink(item.id)}
+                      variant="secondary"
+                      size="default"
+                      className="block w-full text-left px-2 py-1 rounded-sm txt hover:bg-sec transition-colors duration-150"
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      onClick={() => handleDeleteLink(item.id)}
+                      variant="destructive"
+                      size="default"
+                      className="block w-full text-left px-2 py-1 rounded-sm txt hover:bg-sec transition-colors duration-150"
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                )}
               </div>
+            </div>
+          ))}
 
-              {/* Title */}
-              <label className="block mb-4">
-                <span className="text-md  font-semibold  dark:text-gray-300  tracking-wide ">
-                  Title
-                </span>
-                <input
-                  type="text"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  className="w-full mt-1 p-2 border border-gray-500 rounded-lg 
-               bg-transparent txt placeholder:text-sm
-               focus:outline-none focus:ring-2 focus:ring-current"
-                  placeholder="e.g. Amazon"
-                />
-              </label>
+          <Button
+            onClick={handleAddNew}
+            variant="default"
+            size="default"
+            className="w-full px-4 py-2 txt hover:bg-ter rounded-md mt-2 flex items-center gap-2 transition-colors duration-200 border-t border-opacity-20 border-gray-300 pt-3"
+          >
+            <Plus className="w-4 h-4" />
+            <span>Add Link</span>
+          </Button>
+        </div>
+      )}
 
-              {/* Main link */}
-              <label className="block mb-4">
-                <span className="text-md  font-semibold  dark:text-gray-300 tracking-wide">
-                  Links
-                </span>
-                <input
-                  type="text"
-                  value={mainLink}
-                  onChange={(e) => setMainLink(e.target.value)}
-                  className="w-full mt-1 p-2 border border-gray-500 rounded-lg 
-               bg-transparent txt placeholder:text-sm
-               focus:outline-none focus:ring-2 focus:ring-current"
-                  placeholder="e.g. amazon.com (protocol will be added automatically)"
-                />
-              </label>
-
-              {/* Additional tabs/links */}
-              {extraLinks.map((linkVal, idx) => (
-                <div key={idx} className="mb-2">
-                  <input
-                    type="text"
-                    value={linkVal}
-                    onChange={(e) => handleExtraLinkChange(idx, e.target.value)}
-                    className="w-full mt-1 p-2 border border-gray-500 rounded-lg 
-               bg-transparent txt placeholder:text-sm
-               focus:outline-none focus:ring-2 focus:ring-current"
-                    placeholder="Another link..."
-                  />
-                </div>
-              ))}
-
-              {/* "Add another tab" button */}
+      {/* Modal for adding/editing a workspace */}
+      {showModal && (
+        <div className="fixed inset-0 z-50 backdrop-blur-sm bg-black/40 flex items-center justify-center transition-opacity">
+          <div
+            ref={modalRef}
+            className="bg-sec backdrop-blur-xl border border-white/20 p-6 rounded-2xl shadow-2xl max-w-sm w-full transform transition-all duration-200 ease-out scale-100 opacity-100"
+          >
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-xl font-bold txt">
+                {editItemId ? "Edit link" : "Create a link"}
+              </h2>
               <Button
-                type="button"
-                onClick={handleAddAnotherLink}
-                variant="link"
-                size="default"
-                className="text-sm flex font-medium items-center gap-1 mt-2 txt hover:opacity-80 transition-colors"
+                onClick={() => {
+                  setShowModal(false);
+                  setEditItemId(null);
+                  setTitle("");
+                  setMainLink("");
+                  setExtraLinks([]);
+                }}
+                variant="transparent"
+                size="icon"
+                className="p-1 hover:bg-ter rounded"
               >
-                <Plus className="w-4 h-4" />
-                Add another tab
+                <X className="w-5 h-5 txt" />
               </Button>
+            </div>
 
-              {/* Save (Add/Edit) button */}
-              <div className="flex justify-end mt-6">
-                <Button
-                  onClick={handleSaveLink}
-                  variant="default"
-                  size="default"
-                  className="px-4 py-2 rounded txt btn hover:bg-ter/80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-current transition-colors"
-                >
-                  {editItemId ? "Save" : "Add"}
-                </Button>
+            {/* Title */}
+            <label className="block mb-4">
+              <span className="text-md font-semibold dark:text-gray-300 tracking-wide">
+                Title
+              </span>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="w-full mt-1 p-2 border border-gray-500 rounded-lg bg-transparent txt placeholder:text-sm focus:outline-none focus:ring-2 focus:ring-current"
+                placeholder="e.g. Amazon"
+              />
+            </label>
+
+            {/* Main link */}
+            <label className="block mb-4">
+              <span className="text-md font-semibold dark:text-gray-300 tracking-wide">
+                Links
+              </span>
+              <input
+                type="text"
+                value={mainLink}
+                onChange={(e) => setMainLink(e.target.value)}
+                className="w-full mt-1 p-2 border border-gray-500 rounded-lg bg-transparent txt placeholder:text-sm focus:outline-none focus:ring-2 focus:ring-current"
+                placeholder="e.g. amazon.com"
+              />
+            </label>
+
+            {extraLinks.map((linkVal, idx) => (
+              <div key={idx} className="mb-2">
+                <input
+                  type="text"
+                  value={linkVal}
+                  onChange={(e) => handleExtraLinkChange(idx, e.target.value)}
+                  className="w-full mt-1 p-2 border border-gray-500 rounded-lg bg-transparent txt placeholder:text-sm focus:outline-none focus:ring-2 focus:ring-current"
+                  placeholder="Another link..."
+                />
               </div>
-            </motion.div>
-          </motion.div>
-        </AnimatePresence>
+            ))}
+
+            <Button
+              type="button"
+              onClick={handleAddAnotherLink}
+              variant="link"
+              size="default"
+              className="text-sm flex font-medium items-center gap-1 mt-2 txt hover:opacity-80 transition"
+            >
+              <Plus className="w-4 h-4" />
+              Add another tab
+            </Button>
+
+            <div className="flex justify-end mt-6">
+              <Button
+                onClick={handleSaveLink}
+                variant="default"
+                size="default"
+                className="px-4 py-2 rounded txt btn hover:bg-ter/80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-current transition"
+              >
+                {editItemId ? "Save" : "Add"}
+              </Button>
+            </div>
+          </div>
+        </div>
       )}
 
       {/* --- NEW POPUP BLOCKER MODAL --- */}

--- a/Client/src/components/home/navBar/PinnedLinks.jsx
+++ b/Client/src/components/home/navBar/PinnedLinks.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { ExternalLink, Plus, X, MoreVertical } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 
 // Helper to get domain from a URL
@@ -235,177 +236,307 @@ function PinnedLinks() {
       {/* Dropdown of existing pinned links + add button */}
       {/* <AnimatePresence mode="wait"> */}
       {showDropdown && (
-        <div
+        <motion.div
+          initial={{
+            opacity: 0,
+            height: 0,
+            scale: 0.95,
+            y: -8,
+          }}
+          animate={{
+            opacity: 1,
+            height: "auto",
+            scale: 1,
+            y: 0,
+          }}
+          exit={{
+            opacity: 0,
+            height: 0,
+            scale: 0.95,
+            y: -8,
+          }}
+          transition={{
+            duration: 0.15,
+            ease: [0.25, 0.1, 0.25, 1],
+            // height: { duration: 0.35 },
+            // opacity: { duration: 0.25 },
+            // scale: { duration: 0.3 },
+            // y: { duration: 0.3 },
+          }}
           ref={dropdownRef}
-          className="absolute top-full left-0 mt-2 bg-sec shadow-lg rounded-lg p-2 z-10 min-w-[17rem] overflow-hidden backdrop-blur-sm border border-opacity-20 border-gray-300
-          transition-all duration-200 ease-out transform origin-top
-          opacity-100 scale-100"
+          className="absolute top-full left-0 mt-2 bg-sec shadow-lg rounded-lg p-2 z-10 min-w-[17rem] overflow-hidden backdrop-blur-sm border border-opacity-20 border-gray-300"
+          style={{
+            boxShadow:
+              "0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
+          }}
         >
-          {pinnedLinks.map((item) => (
-            <div
-              key={item.id}
-              className="flex items-center justify-between px-4 py-2 txt hover:bg-ter rounded-md transition-colors duration-200"
-            >
-              <div
-                className="flex items-center gap-2 cursor-pointer flex-1"
-                onClick={() => openWorkspace(item.links)}
-              >
-                <div className="flex items-center gap-1">
-                  {item.links.map((link, idx) => (
-                    <img
-                      key={idx}
-                      src={getFaviconUrl(link)}
-                      alt="icon"
-                      className="w-4 h-4 rounded-sm"
-                      onError={(e) => (e.target.style.display = "none")}
-                    />
-                  ))}
-                </div>
-                <span>{item.title}</span>
-              </div>
-
-              <div className="relative">
-                <Button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setOpenMenuId(openMenuId === item.id ? null : item.id);
-                  }}
-                  variant="transparent"
-                  size="icon"
-                  className="p-1 rounded hover:bg-ter transition-colors duration-200"
-                >
-                  <MoreVertical className="w-4 h-4" />
-                </Button>
-
-                {openMenuId === item.id && (
-                  <div
-                    className="absolute right-0 mt-1 bg-ter shadow-lg rounded-md p-1 z-10 min-w-[5rem] border border-opacity-10 border-gray-400
-                    transition-all duration-200 transform origin-top opacity-100 scale-100"
-                  >
-                    <Button
-                      onClick={() => handleEditLink(item.id)}
-                      variant="secondary"
-                      size="default"
-                      className="block w-full text-left px-2 py-1 rounded-sm txt hover:bg-sec transition-colors duration-150"
-                    >
-                      Edit
-                    </Button>
-                    <Button
-                      onClick={() => handleDeleteLink(item.id)}
-                      variant="destructive"
-                      size="default"
-                      className="block w-full text-left px-2 py-1 rounded-sm txt hover:bg-sec transition-colors duration-150"
-                    >
-                      Delete
-                    </Button>
-                  </div>
-                )}
-              </div>
-            </div>
-          ))}
-
-          <Button
-            onClick={handleAddNew}
-            variant="default"
-            size="default"
-            className="w-full px-4 py-2 txt hover:bg-ter rounded-md mt-2 flex items-center gap-2 transition-colors duration-200 border-t border-opacity-20 border-gray-300 pt-3"
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.1, duration: 0.3 }}
           >
-            <Plus className="w-4 h-4" />
-            <span>Add Link</span>
-          </Button>
-        </div>
-      )}
-
-      {/* Modal for adding/editing a workspace */}
-      {showModal && (
-        <div className="fixed inset-0 z-50 backdrop-blur-sm bg-black/40 flex items-center justify-center transition-opacity">
-          <div
-            ref={modalRef}
-            className="bg-sec backdrop-blur-xl border border-white/20 p-6 rounded-2xl shadow-2xl max-w-sm w-full transform transition-all duration-200 ease-out scale-100 opacity-100"
-          >
-            <div className="flex justify-between items-center mb-4">
-              <h2 className="text-xl font-bold txt">
-                {editItemId ? "Edit link" : "Create a link"}
-              </h2>
-              <Button
-                onClick={() => {
-                  setShowModal(false);
-                  setEditItemId(null);
-                  setTitle("");
-                  setMainLink("");
-                  setExtraLinks([]);
+            {pinnedLinks.map((item, index) => (
+              <motion.div
+                key={item.id}
+                initial={{
+                  opacity: 0,
+                  x: -20,
+                  filter: "blur(4px)",
                 }}
-                variant="transparent"
-                size="icon"
-                className="p-1 hover:bg-ter rounded"
+                animate={{
+                  opacity: 1,
+                  x: 0,
+                  filter: "blur(0px)",
+                }}
+                transition={{
+                  delay: index * 0.05,
+                  duration: 0.2,
+                  ease: [0.15, 0.05, 0.15, 1],
+                }}
+                whileHover={{ scale: 1.02 }}
+                className="flex items-center justify-between px-4 py-2 txt hover:bg-ter rounded-md transition-colors duration-200"
               >
-                <X className="w-5 h-5 txt" />
-              </Button>
-            </div>
+                <motion.div
+                  className="flex items-center gap-2 cursor-pointer flex-1"
+                  onClick={() => openWorkspace(item.links)}
+                  whileTap={{ scale: 0.98 }}
+                >
+                  <motion.div
+                    className="flex items-center gap-1"
+                    initial={{ scale: 0.8 }}
+                    animate={{ scale: 1 }}
+                    transition={{ delay: index * 0.05, duration: 0.2 }}
+                  >
+                    {item.links.map((link, idx) => (
+                      <motion.img
+                        key={idx}
+                        src={getFaviconUrl(link)}
+                        alt="icon"
+                        className="w-4 h-4 rounded-sm"
+                        initial={{ opacity: 0, rotate: -90 }}
+                        animate={{ opacity: 1, rotate: 0 }}
+                        transition={{
+                          delay: index * 0.05 + idx * 0.02,
+                          duration: 0.4,
+                        }}
+                        onError={(e) => {
+                          e.target.style.display = "none";
+                        }}
+                      />
+                    ))}
+                  </motion.div>
+                  <motion.span
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transition={{ delay: index * 0.05, duration: 0.3 }}
+                  >
+                    {item.title}
+                  </motion.span>
+                </motion.div>
 
-            {/* Title */}
-            <label className="block mb-4">
-              <span className="text-md font-semibold dark:text-gray-300 tracking-wide">
-                Title
-              </span>
-              <input
-                type="text"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                className="w-full mt-1 p-2 border border-gray-500 rounded-lg bg-transparent txt placeholder:text-sm focus:outline-none focus:ring-2 focus:ring-current"
-                placeholder="e.g. Amazon"
-              />
-            </label>
+                <div className="relative">
+                  <Button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setOpenMenuId(openMenuId === item.id ? null : item.id);
+                    }}
+                    variant="transparent"
+                    size="icon"
+                    className="p-1 rounded hover:bg-ter transition-colors duration-200"
+                  >
+                    <MoreVertical className="w-4 h-4" />
+                  </Button>
 
-            {/* Main link */}
-            <label className="block mb-4">
-              <span className="text-md font-semibold dark:text-gray-300 tracking-wide">
-                Links
-              </span>
-              <input
-                type="text"
-                value={mainLink}
-                onChange={(e) => setMainLink(e.target.value)}
-                className="w-full mt-1 p-2 border border-gray-500 rounded-lg bg-transparent txt placeholder:text-sm focus:outline-none focus:ring-2 focus:ring-current"
-                placeholder="e.g. amazon.com"
-              />
-            </label>
-
-            {extraLinks.map((linkVal, idx) => (
-              <div key={idx} className="mb-2">
-                <input
-                  type="text"
-                  value={linkVal}
-                  onChange={(e) => handleExtraLinkChange(idx, e.target.value)}
-                  className="w-full mt-1 p-2 border border-gray-500 rounded-lg bg-transparent txt placeholder:text-sm focus:outline-none focus:ring-2 focus:ring-current"
-                  placeholder="Another link..."
-                />
-              </div>
+                  <AnimatePresence>
+                    {openMenuId === item.id && (
+                      <motion.div
+                        initial={{
+                          opacity: 0,
+                          scale: 0.9,
+                          y: -5,
+                        }}
+                        animate={{
+                          opacity: 1,
+                          scale: 1,
+                          y: 0,
+                        }}
+                        exit={{
+                          opacity: 0,
+                          scale: 0.9,
+                          y: -5,
+                        }}
+                        transition={{
+                          duration: 0.2,
+                          ease: [0.25, 0.46, 0.45, 0.94],
+                        }}
+                        className="absolute right-0 mt-1 bg-ter shadow-lg rounded-md p-1 z-10 min-w-[5rem] border border-opacity-10 border-gray-400"
+                      >
+                        <Button
+                          onClick={() => handleEditLink(item.id)}
+                          variant="secondary"
+                          size="default"
+                          className="block w-full text-left px-2 py-1 rounded-sm txt hover:bg-sec transition-colors duration-150"
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          onClick={() => handleDeleteLink(item.id)}
+                          variant="destructive"
+                          size="default"
+                          className="block w-full text-left px-2 py-1 rounded-sm txt hover:bg-sec transition-colors duration-150"
+                        >
+                          Delete
+                        </Button>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </div>
+              </motion.div>
             ))}
 
             <Button
-              type="button"
-              onClick={handleAddAnotherLink}
-              variant="link"
+              onClick={handleAddNew}
+              variant="default"
               size="default"
-              className="text-sm flex font-medium items-center gap-1 mt-2 txt hover:opacity-80 transition"
+              className="w-full px-4 py-2 txt hover:bg-ter rounded-md mt-2 flex items-center gap-2 transition-colors duration-200 border-t border-opacity-20 border-gray-300 pt-3"
             >
-              <Plus className="w-4 h-4" />
-              Add another tab
-            </Button>
-
-            <div className="flex justify-end mt-6">
-              <Button
-                onClick={handleSaveLink}
-                variant="default"
-                size="default"
-                className="px-4 py-2 rounded txt btn hover:bg-ter/80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-current transition"
+              <motion.div
+                initial={{ rotate: -90, scale: 0.8 }}
+                animate={{ rotate: 0, scale: 1 }}
+                transition={{
+                  delay: 0.45 + pinnedLinks.length * 0.05,
+                  duration: 0.2,
+                }}
               >
-                {editItemId ? "Save" : "Add"}
+                <Plus className="w-4 h-4" />
+              </motion.div>
+              <motion.span
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{
+                  delay: 0.2 + pinnedLinks.length * 0.05,
+                  duration: 0.2,
+                }}
+              >
+                Add Link
+              </motion.span>
+            </Button>
+          </motion.div>
+        </motion.div>
+      )}
+      {/* </AnimatePresence> */}
+
+      {/* Modal for adding/editing a workspace */}
+      {showModal && (
+        <AnimatePresence>
+          <motion.div
+            key="backdrop"
+            className="fixed inset-0 z-50 backdrop-blur-sm bg-black/40 flex items-center justify-center transition-colors"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <motion.div
+              key="modal"
+              initial={{ opacity: 0, scale: 0.95, y: 20 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 20 }}
+              transition={{ duration: 0.25, ease: "easeInOut" }}
+              className="bg-sec backdrop-blur-xl border border-white/20 p-6 rounded-2xl shadow-2xl max-w-sm w-full "
+            >
+              <div className="flex justify-between items-center mb-4">
+                <h2 className="text-xl font-bold txt">
+                  {editItemId ? "Edit link" : "Create a link"}
+                </h2>
+                <Button
+                  onClick={() => {
+                    setShowModal(false);
+                    setEditItemId(null);
+                    setTitle("");
+                    setMainLink("");
+                    setExtraLinks([]);
+                  }}
+                  variant="transparent"
+                  size="icon"
+                  className="p-1 hover:bg-ter rounded"
+                >
+                  <X className="w-5 h-5 txt" />
+                </Button>
+              </div>
+
+              {/* Title */}
+              <label className="block mb-4">
+                <span className="text-md  font-semibold  dark:text-gray-300  tracking-wide ">
+                  Title
+                </span>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  className="w-full mt-1 p-2 border border-gray-500 rounded-lg 
+               bg-transparent txt placeholder:text-sm
+               focus:outline-none focus:ring-2 focus:ring-current"
+                  placeholder="e.g. Amazon"
+                />
+              </label>
+
+              {/* Main link */}
+              <label className="block mb-4">
+                <span className="text-md  font-semibold  dark:text-gray-300 tracking-wide">
+                  Links
+                </span>
+                <input
+                  type="text"
+                  value={mainLink}
+                  onChange={(e) => setMainLink(e.target.value)}
+                  className="w-full mt-1 p-2 border border-gray-500 rounded-lg 
+               bg-transparent txt placeholder:text-sm
+               focus:outline-none focus:ring-2 focus:ring-current"
+                  placeholder="e.g. amazon.com (protocol will be added automatically)"
+                />
+              </label>
+
+              {/* Additional tabs/links */}
+              {extraLinks.map((linkVal, idx) => (
+                <div key={idx} className="mb-2">
+                  <input
+                    type="text"
+                    value={linkVal}
+                    onChange={(e) => handleExtraLinkChange(idx, e.target.value)}
+                    className="w-full mt-1 p-2 border border-gray-500 rounded-lg 
+               bg-transparent txt placeholder:text-sm
+               focus:outline-none focus:ring-2 focus:ring-current"
+                    placeholder="Another link..."
+                  />
+                </div>
+              ))}
+
+              {/* "Add another tab" button */}
+              <Button
+                type="button"
+                onClick={handleAddAnotherLink}
+                variant="link"
+                size="default"
+                className="text-sm flex font-medium items-center gap-1 mt-2 txt hover:opacity-80 transition-colors"
+              >
+                <Plus className="w-4 h-4" />
+                Add another tab
               </Button>
-            </div>
-          </div>
-        </div>
+
+              {/* Save (Add/Edit) button */}
+              <div className="flex justify-end mt-6">
+                <Button
+                  onClick={handleSaveLink}
+                  variant="default"
+                  size="default"
+                  className="px-4 py-2 rounded txt btn hover:bg-ter/80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-current transition-colors"
+                >
+                  {editItemId ? "Save" : "Add"}
+                </Button>
+              </div>
+            </motion.div>
+          </motion.div>
+        </AnimatePresence>
       )}
 
       {/* --- NEW POPUP BLOCKER MODAL --- */}

--- a/Client/src/components/home/navBar/PinnedLinks.jsx
+++ b/Client/src/components/home/navBar/PinnedLinks.jsx
@@ -276,25 +276,9 @@ function PinnedLinks() {
             transition={{ delay: 0.1, duration: 0.3 }}
           >
             {pinnedLinks.map((item, index) => (
-              <motion.div
+              <div
                 key={item.id}
-                initial={{
-                  opacity: 0,
-                  x: -20,
-                  filter: "blur(4px)",
-                }}
-                animate={{
-                  opacity: 1,
-                  x: 0,
-                  filter: "blur(0px)",
-                }}
-                transition={{
-                  delay: index * 0.05,
-                  duration: 0.2,
-                  ease: [0.15, 0.05, 0.15, 1],
-                }}
-                whileHover={{ scale: 1.02 }}
-                className="flex items-center justify-between px-4 py-2 txt hover:bg-ter rounded-md transition-colors duration-200"
+                className="flex items-center justify-between px-4 py-2 txt hover:bg-ter rounded-md transition-all duration-200 hover:px-3"
               >
                 <motion.div
                   className="flex items-center gap-2 cursor-pointer flex-1"
@@ -391,7 +375,7 @@ function PinnedLinks() {
                     )}
                   </AnimatePresence>
                 </div>
-              </motion.div>
+              </div>
             ))}
 
             <Button


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what this PR does. -->
To fixed the motion stacking context issue during hovering over link row items, removed the framer motion entairly from PinnedLinks component and to reach similer effects/transition used native tailwind CSS utility classes.

## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #816 

## Changes Made
<!-- List the changes made in this PR. -->
- [x] Updated `PinnedLinks.jsx`
- [ ] Added ...

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->
https://github.com/user-attachments/assets/759abae4-5267-4b88-bc3d-5626f0d1c3d4

## checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [ ] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.
