### PR TITLE
fix: Allow user data in education and skills section to store data

### DIFF
--- a/Client/src/components/settings/EducationAndSkills.jsx
+++ b/Client/src/components/settings/EducationAndSkills.jsx
@@ -39,7 +39,7 @@ function EducationAndSkills() {
 
         if (!user) {
           fetchUserDetails(decoded.id);
-        } else {
+        } else if (!initialData) { 
           const initial = {
             University: user.University || "",
             FieldOfStudy: user.FieldOfStudy || "",


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what this PR does. -->
The `Education & Skills` section has a bug., which is not allowing users to make changes while entering their university name or their graduations year. Now the bug is been resolved. And the user entered data is being saved correctly!
## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #875 

## Changes Made
<!-- List the changes made in this PR. -->
- [X] Updated the code...
- [X] Added the required changes only..

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->
BEFORE : The red marked areas were not even enabling the users to write. (i.e, "vanishing text")
<img width="1280" height="680" alt="image" src="https://github.com/user-attachments/assets/13b2b2e5-d05f-4039-929e-3b26c7f9020a" />
AFTER :  Being abled to save the user's data.
<img width="1065" height="852" alt="image" src="https://github.com/user-attachments/assets/29822ca3-2bea-43ba-a105-080819f908b7" />

## checklist

- [X] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [X] Only the necessary files are modified; no unrelated changes are included.
- [X] Follows clean code principles (readable, maintainable, minimal duplication).
- [X] All changes are clearly documented.
- [X] Code has been tested across all supported themes and verified against potential edge cases.
- [X] Multiple screenshots or recordings are attached (if required).
- [X] No breaking changes are introduced to existing functionality.

## Additional Notes
<!-- Add any other relevant information or context. -->
ntg