### PR TITLE
Stats: refine auth/loading handling and add loading skeletons

### DIFF
--- a/Client/src/components/AdCard.jsx
+++ b/Client/src/components/AdCard.jsx
@@ -57,10 +57,7 @@ function AdCard({ slideInterval = 30000 }) {
 
   return (
     <div className="group space-y-2.5">
-      <a
-        href={currentProductData.url}
-        target="_blank"
-        rel="noopener noreferrer"
+      <div
         className="flex flex-row  gap-4"
       >
         <img
@@ -86,7 +83,7 @@ function AdCard({ slideInterval = 30000 }) {
             </a>
           </div>
         </div>
-      </a>
+      </div>
 
       {/* Carousel area with fade */}
       <div className="relative aspect-video overflow-hidden w-full">

--- a/Client/src/components/stats/Leaderboard.jsx
+++ b/Client/src/components/stats/Leaderboard.jsx
@@ -10,6 +10,24 @@ import { ChevronDown } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
 
+const LeaderboardItemSkeleton = () => {
+  return (
+    <div className="flex items-center justify-between px-4 py-3 transition-all">
+      <div className="flex gap-4 items-center justify-between w-full">
+
+        <div className="w-8 h-6 rounded-full bg-ter animate-pulse" />
+
+        <div className="flex  items-center flex-1 gap-2">
+          <div className="w-8 h-8 rounded-full bg-ter animate-pulse" />
+          <div className="w-1/2 h-4 rounded-xl bg-ter animate-pulse" />
+        </div>
+
+        <div className="w-8 h-4 rounded-xl bg-ter animate-pulse" />
+      </div>
+    </div>
+  );
+};
+
 const Leaderboard = () => {
   const { userId } = useParams();
   const location = useLocation();
@@ -152,69 +170,72 @@ const Leaderboard = () => {
       </div>
 
       {/* Leaderboard Content */}
-      <div
-        className={`space-y-2 transition-all duration-500 ${
-          isLoading ? "opacity-0 -translate-y-2" : "opacity-100 translate-y-0"
-        } min-h-[450px]`}
-      >
-        {!isLoading && leaderboard.length === 0 ? (
-          <div className="flex items-center justify-center h-full text-[var(--txt-dim)] text-sm font-medium">
-            No records found for this timeframe.
-          </div>
-        ) : (
-          leaderboard.slice(0, 10).map((user, index) => {
-            const isCurrentUser = user.userId === currentUserId;
-            return (
-              <div
-                key={user.userId}
-                className={`flex items-center justify-between px-5 py-3 rounded-xl transition-all text-sm ${
-                  user.userId === highlightedUserId
-                    ? "bg-[var(--btn)] text-white"
-                    : "hover:bg-[var(--bg-ter)] text-[var(--txt)]"
-                }`}
-              >
-                <div className="flex gap-2">
-                  <div className="flex justify-start min-w-9">
-                    {getBadge(index)}
-                  </div>
-                  <Link
-                    to={isCurrentUser ? "/stats" : `/user/${user.userId}`}
-                    className="text-center font-semibold flex items-center gap-2"
-                  >
-                    {/* Show user's profile picture before their name. If the image fails, track the userId in imageErrorIds so we don't retry rendering a broken image. */}
-                    {user.profilePicture && !imageErrorIds.has(user.userId) ? (
-                      <img
-                        src={user.profilePicture}
-                        alt={`${user.username}'s avatar`}
-                        className="w-7 h-7 rounded-full object-cover flex-shrink-0"
-                        referrerPolicy="no-referrer"
-                        onError={() => {
-                          setImageErrorIds((prev) => {
-                            const next = new Set(prev);
-                            next.add(user.userId);
-                            return next;
-                          });
-                        }}
-                      />
-                    ) : null}
-                    <span className="truncate max-w-[12rem] 2xl:max-w-[9.5rem] inline-block align-middle">
-                      {user.username}
-                    </span>
-                  </Link>
-                </div>
-
+      {isLoading ? (
+        <div className="space-y-2 min-h-[450px]">
+          <LeaderboardItemSkeleton />
+          <LeaderboardItemSkeleton />
+          <LeaderboardItemSkeleton />
+        </div>
+      ) : (
+        <div className="space-y-2 transition-all duration-500 opacity-100 translate-y-0 min-h-[450px]">
+          {leaderboard.length === 0 ? (
+            <div className="flex items-center justify-center h-full text-[var(--txt-dim)] text-sm font-medium">
+              No records found for this timeframe.
+            </div>
+          ) : (
+            leaderboard.slice(0, 10).map((user, index) => {
+              const isCurrentUser = user.userId === currentUserId;
+              return (
                 <div
-                  className={`text-right font-medium ${
-                    isCurrentUser ? "text-white" : "text-[var(--txt-dim)]"
+                  key={user.userId}
+                  className={`flex items-center justify-between px-5 py-3 rounded-xl transition-all text-sm ${
+                    user.userId === highlightedUserId
+                      ? "bg-[var(--btn)] text-white"
+                      : "hover:bg-[var(--bg-ter)] text-[var(--txt)]"
                   }`}
                 >
-                  {formatDuration(user.totalDuration)}
+                  <div className="flex gap-2">
+                    <div className="flex justify-start min-w-9">
+                      {getBadge(index)}
+                    </div>
+                    <Link
+                      to={isCurrentUser ? "/stats" : `/user/${user.userId}`}
+                      className="text-center font-semibold flex items-center gap-2"
+                    >
+                      {user.profilePicture && !imageErrorIds.has(user.userId) ? (
+                        <img
+                          src={user.profilePicture}
+                          alt={`${user.username}'s avatar`}
+                          className="w-7 h-7 rounded-full object-cover flex-shrink-0"
+                          referrerPolicy="no-referrer"
+                          onError={() => {
+                            setImageErrorIds((prev) => {
+                              const next = new Set(prev);
+                              next.add(user.userId);
+                              return next;
+                            });
+                          }}
+                        />
+                      ) : null}
+                      <span className="truncate max-w-[12rem] 2xl:max-w-[9.5rem] inline-block align-middle">
+                        {user.username}
+                      </span>
+                    </Link>
+                  </div>
+
+                  <div
+                    className={`text-right font-medium ${
+                      isCurrentUser ? "text-white" : "text-[var(--txt-dim)]"
+                    }`}
+                  >
+                    {formatDuration(user.totalDuration)}
+                  </div>
                 </div>
-              </div>
-            );
-          })
-        )}
-      </div>
+              );
+            })
+          )}
+        </div>
+      )}
 
       {/* Footer */}
       {currentUser && leaderboard.length > 0 && (

--- a/Client/src/components/stats/MonthlyLevel.jsx
+++ b/Client/src/components/stats/MonthlyLevel.jsx
@@ -18,8 +18,21 @@ const MonthlyLevel = () => {
 
   if (isLoading) {
     return (
-      <div className="bg-[var(--bg-sec)] rounded-3xl shadow-md p-6 flex items-center justify-center w-full">
-        <p>Loading...</p>
+      <div className="bg-[var(--bg-sec)] rounded-3xl shadow-md p-6 flex flex-col gap-4 w-full">
+        <div className="flex justify-between">
+          <h3 className="text-xl font-semibold txt">Monthly Level</h3>
+          <p className="flex gap-1 items-end txt-dim">Total: <span className="w-10 h-5 bg-ter rounded-lg animate-pulse inline-block mb-0.5"></span></p>
+        </div>
+        <div className="flex items-center gap-4 animate-pulse">
+          <div className="w-28 h-28 bg-ter rounded-full"></div>
+          <div className="flex flex-col flex-1 gap-2">
+            <p className="w-full h-10 bg-ter rounded-full"></p>
+            <p className="w-2/3 h-5 bg-ter rounded-xl"></p>
+          </div>
+        </div>
+        <div className="w-full">
+          <div className="h-10 w-full rounded-full bg-ter animate-pulse"></div>
+        </div>
       </div>
     );
   }

--- a/Client/src/components/stats/StudyStats.jsx
+++ b/Client/src/components/stats/StudyStats.jsx
@@ -161,6 +161,66 @@ const computeSummary = (data) => {
   return { totalStudyHours, avgDaily, maxStudyHours };
 };
 
+const StatsSkeleton = () => (
+  <div className="bg-ter rounded-3xl flex items-center">
+    <div className="flex bg-[var(--bg-sec)] shadow-md rounded-3xl text-center w-full overflow-hidden p-6">
+      <div className="w-full space-y-6">
+
+        <div className="flex justify-between items-center">
+          {/* Stats */}
+          <div className="flex gap-6 flex-wrap justify-center">
+            <div className="flex gap-2">Total Study Hours: 
+              <p className="h-6 bg-ter rounded-xl w-12 md:w-16 animate-pulse"></p>
+            </div>
+            <div className="flex gap-2">Average: 
+              <p className="h-6 bg-ter rounded-xl w-12 md:w-16 animate-pulse"></p>
+            </div>
+            <div className="flex gap-2">Maximum: 
+              <p className="h-6 bg-ter rounded-xl w-12 md:w-16 animate-pulse"></p>
+            </div>
+          </div>
+          
+          {/* Dropdown  */}
+          <div className="h-8 bg-ter rounded-xl w-24 animate-pulse"></div>
+        </div>
+        
+        {/* Chart Area Skeleton */}
+        <div className="relative h-64 w-full">
+
+          <div className="absolute inset-0 flex flex-col justify-between">
+            {[...Array(5)].map((_, i) => (
+              <div key={i} className="h-px bg-ter"></div>
+            ))}
+          </div>
+          
+          <div className="absolute inset-0 flex justify-between">
+            {[...Array(7)].map((_, i) => (
+              <div key={i} className="w-px bg-ter h-full"></div>
+            ))}
+          </div>
+        </div>
+        
+        {/* labels*/}
+        <div className="flex justify-between px-2">
+          {[...Array(7)].map((_, i) => (
+            <div key={i} className="h-4 bg-ter rounded w-10 md:w-16 animate-pulse"></div>
+          ))}
+        </div>
+      </div>
+    </div>
+
+    {/* side stats */}
+    <div className="text-sm p-6 text-left w-fit flex flex-col gap-2">
+      Rank: 
+      <div className="h-10 w-5 bg-sec rounded-lg animate-pulse"></div>
+      Current Streak:
+      <div className="h-10 w-5 bg-sec rounded-lg animate-pulse"></div>
+      Max Streak:
+      <div className="h-10 w-5 bg-sec rounded-lg animate-pulse"></div>
+    </div>
+  </div>
+)
+
 // ──────────────────────────────────────────────────────────────
 // Main Component
 // ──────────────────────────────────────────────────────────────
@@ -215,9 +275,7 @@ const StudyStats = () => {
   // Add loading and error states
   if (isLoading) {
     return (
-      <div className="flex bg-[var(--bg-ter)] shadow-md rounded-3xl text-center w-full overflow-hidden p-6">
-        <p>Loading study statistics...</p>
-      </div>
+      <StatsSkeleton />
     );
   }
 
@@ -252,7 +310,7 @@ const StudyStats = () => {
               </Button>
             </DropdownMenuTrigger>
             {isOpen && (
-              <DropdownMenuContent align="end" classname="border-none">
+              <DropdownMenuContent align="end" className="border-none">
                 <DropdownMenuItem onClick={() => handleDropdownClick("hourly")}>
                   Hourly
                 </DropdownMenuItem>

--- a/Client/src/pages/Stats.jsx
+++ b/Client/src/pages/Stats.jsx
@@ -16,14 +16,18 @@ const Stats = ({ isCurrentUser = false }) => {
   const { userId } = useParams();
   const { user: currentUser, fetchUserDetails } = useUserProfile();
   const [userStats, setUserStats] = useState(null);
-  const [loading, setLoading] = useState(true);
+  // const [loading, setLoading] = useState(true);
+  const [fetched, setFetched] = useState(false);
 
   useEffect(() => {
     const fetchStats = async () => {
       try {
         if (isCurrentUser) {
           const token = localStorage.getItem("token");
-          if (!token) return;
+          if (!token) {
+            setFetched(true);
+            return;
+          };
 
           const decoded = jwtDecode(token);
           await fetchUserDetails(decoded.id);
@@ -68,30 +72,29 @@ const Stats = ({ isCurrentUser = false }) => {
       } catch (error) {
         console.error("Error fetching user stats:", error);
       } finally {
-        setLoading(false);
+        setFetched(true);
       }
     };
 
     fetchStats();
   }, [isCurrentUser, userId, currentUser, fetchUserDetails]);
 
-  if (isCurrentUser && !currentUser) {
+  if (fetched && isCurrentUser && !currentUser) {
     return <NotLogedInPage />;
   }
 
-  if (loading) return <div className="m-3 2xl:m-6">Loading profile...</div>;
-  if (!userStats)
+  if (fetched && !userStats)
     return (
       <div className="m-3 2xl:m-6">
         User not found or error loading profile.
       </div>
-    );
+  );
 
   return (
     <div className="m-3 2xl:m-6">
       <div className="flex justify-between items-center mb-3 2xl:mb-6">
         <h1 className="text-2xl font-bold">
-          {isCurrentUser ? "Analytics" : userStats.name}
+          {isCurrentUser ? "Analytics" : userStats?.name || ""}
         </h1>
         {isCurrentUser && (
           <div className="flex items-center gap-4">
@@ -110,26 +113,26 @@ const Stats = ({ isCurrentUser = false }) => {
 
         <div className="flex-1">
           <div className="mb-3 2xl:mb-6">
-            <StudyStats stats={userStats.studyStats} />
+            <StudyStats stats={userStats?.studyStats} />
           </div>
           <div className="flex flex-col xl:flex-col 2xl:flex-row">
             <div className="flex-1 mr-0 2xl:mr-6">
               <div className="flex gap-3 2xl:gap-6 mb-4 2xl:mb-6">
-                <MonthlyLevel data={userStats.monthlyLevel} />
-                <Badges data={userStats.badges} />
+                <MonthlyLevel data={userStats?.monthlyLevel} />
+                <Badges data={userStats?.badges} />
               </div>
               <div className="gap-3 2xl:gap-6 mb-3 2xl:mb-6">
-                <Goals goals={userStats.goals} isCurrentUser={isCurrentUser} />
+                <Goals goals={userStats?.goals} isCurrentUser={isCurrentUser} />
               </div>
             </div>
             <div>
-              <Leaderboard data={userStats.leaderboard} />
+              <Leaderboard data={userStats?.leaderboard} />
             </div>
           </div>
         </div>
       </div>
 
-      <Test data={userStats.testData} />
+      <Test data={userStats?.testData} />
     </div>
   );
 };


### PR DESCRIPTION
## Description
This PR improves the stats page’s auth/loading flow to prevent premature “not logged in” or error states and introduces loading skeletons during data fetches. It centralizes loading in child components, adds a fetched guard before showing NotLoggedInPage, and uses optional chaining to avoid crashes from undefined props.

## Related Issue
Bug: fix UI in stats page #327

## Changes Made
- [x] Refine auth and loading control in `Stats.jsx` using a `fetched` state.
- [x] Prevent premature “not found/error” renders until fetch completes.
- [x] Delegate loading states to child components to reduce layout shift.
- [x] Add loading skeletons to: `Leaderboard.jsx`, `MonthlyLevel.jsx` and `StudyStats.jsx`.
- [x] Use optional chaining when passing props to children to prevent runtime crashes.
- [x] Minor cleanup in `AdCard.jsx`.

## Screenshots or GIFs (if applicable)
<img width="1920" height="2187" alt="web" src="https://github.com/user-attachments/assets/cabf50aa-1297-4533-a12b-0ef3d2fd5672" />


## Checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.

## Additional Notes
Review the loading/exit conditions in `Stats.jsx` and the new skeleton logic in child components.
