### PR TITLE
fixed join session bug

### DIFF
--- a/Client/src/components/session/CreateRoomModal.jsx
+++ b/Client/src/components/session/CreateRoomModal.jsx
@@ -98,6 +98,20 @@ function CreateRoomModal({ isOpen, onClose, onCreate }) {
               className="w-full px-4 py-3 mb-6 rounded-lg bg-sec txt placeholder:txt-dim border border-gray-500/50 focus:outline-none"
             />
 
+            {/* Privacy */}
+            <div className="flex items-center gap-3 mb-6">
+              <input
+                id="private-room"
+                type="checkbox"
+                checked={isPrivate}
+                onChange={(e) => setIsPrivate(e.target.checked)}
+                className="h-4 w-4"
+              />
+              <label htmlFor="private-room" className="font-medium txt">
+                Make this room private
+              </label>
+            </div>
+
             {/* Actions */}
             <div className="flex justify-end gap-4">
               <Button

--- a/Server/Routes/SessionRoomRoutes.js
+++ b/Server/Routes/SessionRoomRoutes.js
@@ -8,6 +8,7 @@ import {
   handleJoinRequest,
   joinRoom,
   getJoinStatus,
+  cancelJoinRequest,
 } from "../Controller/SessionRoomController.js";
 // Get current user's join status for a room
 
@@ -20,6 +21,8 @@ router.delete("/:id", authMiddleware, deleteRoom);
 
 // Join request for private room
 router.post("/:id/request-join", authMiddleware, requestJoinRoom);
+// Cancel join request for private room
+router.post("/:id/cancel-request", authMiddleware, cancelJoinRequest);
 // Approve/reject join request (room creator)
 router.post("/:id/handle-request", authMiddleware, handleJoinRequest);
 // Join a room (public or if member)


### PR DESCRIPTION
## Title
Fix private room flow: dynamic buttons + cancel request endpoint

## Description
- Add “Make this room private” in create modal; send `isPrivate`.
- Dynamic room actions: Request Join, Cancel Request, Enter Room, Join.
- Join before navigate; add `POST /session-room/:id/cancel-request`.
- Auto-refresh join status (poll + on tab focus).

## Related Issue
Fixes #861

## Changes
- Backend: add cancel endpoint; ensure private creators in `members`; join/join-status solid.
- Client: `CreateRoomModal.jsx` checkbox; `RoomCard.jsx` dynamic buttons, cancel, polling.

## Screenshots
<img width="493" height="403" alt="image" src="https://github.com/user-attachments/assets/1f8d4fa6-956b-4bc3-9b9b-3eeff77d9e5c" />

## Checklist
- [x] Prettier formatting respected
- [x] Only necessary files changed
- [x] Clean, readable code
- [x] Clear change notes in PR
- [x] Tested key flows and edge cases
- [x] Screenshots/recordings attached (to be added by reviewer/author)
- [x] No breaking changes