### PR TITLE
Remove Extra scrollable div

### DIFF
--- a/Client/src/components/friendsPage/tabs/SuggestedFriends.jsx
+++ b/Client/src/components/friendsPage/tabs/SuggestedFriends.jsx
@@ -24,7 +24,7 @@ export default function FindPeople() {
         placeholder="Search by name, email, skills, or interests..."
       />
 
-      <div id="scrollableDiv2" style={{ height: "calc(100vh - 92px)", overflow: "auto" }}>
+      <div id="scrollableDiv2" style={{ overflow: "auto" }}>
         {isLoading && <FriendsSkeletonLoader />}
 
         {!isLoading && !isFetchingNextPage && users.length === 0 && (


### PR DESCRIPTION
Closes https://github.com/EduHaven/EduHaven/issues/898

> The inline style for the scrollable div in SuggestedFriends.jsx no longer sets a fixed height, allowing it to adapt dynamically. This improves layout flexibility and prevents potential overflow issues on different screen sizes.

<img width="619" height="950" alt="image" src="https://github.com/user-attachments/assets/0e26e77e-4b7a-4b4c-9b0b-0b09cac6c57b" />

## Changes made
- Removed extra Scrollbar

## Outcome 
- Now navigated- https://eduhaven.online/friends?tab=findFriends will get only one scrollbar

### Please let me know if need any more changes...! 😇