### PR TITLE
Handle removing collaborators from notes

### DIFF
--- a/Server/Routes/NotesRoutes.js
+++ b/Server/Routes/NotesRoutes.js
@@ -16,6 +16,7 @@ import {
   updateNote,
   uploadNoteImage,
   addCollaborator,
+  removeCollaborator,
   generateShareLink,
   getSharedNote,
 } from "../Controller/NotesController.js";
@@ -114,6 +115,7 @@ router.delete("/:id", authMiddleware, deleteNote);
 router.post("/deleteimage", authMiddleware, deleteNoteImage);
 
 router.post('/:noteId/collaborators', authMiddleware, addCollaborator);
+router.delete('/:noteId/collaborators/:collaboratorId', authMiddleware, removeCollaborator);
 
 router.post("/:noteId/generate-share-link", authMiddleware, generateShareLink);
 router.get("/shared/:shareToken", getSharedNote);


### PR DESCRIPTION
## Description
when we share a note with any user, we can't remove his/her access. This pr allows us to remove access from any collaborator from the list of users shown on clicking share button

## Related Issue
Fixes #914 

## Changes Made
- Updated `Client/src/components/notes/SharePopup.jsx` for handling remove function.
- updated `Server/Controller/NotesController.js` added controller to remove access from db.
- updated `Server/Routes/NotesRoutes.js` added route for removing access.


## checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.

## Additional Notes
Making a new issue for better state management of notes.
