### PR TITLE
Refactor list item styles in ProseMirror for improved marker visibility

### DIFF
--- a/Client/src/components/notes/note.css
+++ b/Client/src/components/notes/note.css
@@ -65,11 +65,13 @@ body {
   list-style-type: decimal;
 }
 
+.ProseMirror ul li::marker,
+.ProseMirror ol li::marker {
+  color: var(--txt);
+}
+
 .ProseMirror li {
   margin: 0.25em 0;
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
 
 .ProseMirror blockquote {
@@ -130,11 +132,11 @@ body {
   padding: 0;
 }
 
-/* .ProseMirror .task-list li {
+.ProseMirror ul[data-type="taskList"] li {
   display: flex;
   align-items: center;
   gap: 8px;
-} */
+}
 
 /* .ProseMirror .task-list li label {
   display: flex;


### PR DESCRIPTION
Fix Issue : https://github.com/EduHaven/EduHaven/issues/921

# Fix List Indicators Visibility

## Changes Made

- **CSS Updates in `note.css`**:
  - Added `color: var(--txt)` to `.ProseMirror ul li::marker` and `.ProseMirror ol li::marker` to ensure list bullets/numbers match text color
  - Removed `display: flex` from general `.ProseMirror li` to allow default list markers to display properly
  - Added `display: flex` specifically to `.ProseMirror ul[data-type="taskList"] li` to maintain checkbox alignment in task lists

## Problem Solved

List indicators (bullets and numbers) were not visible or properly colored on different note background colors. Now they appear clearly and match the text color across all themes.

<img width="823" height="340" alt="Screenshot from 2025-10-10 09-46-42" src="https://github.com/user-attachments/assets/218adf49-2cfb-4622-a6a4-9774eaad9897" />
