### PR TITLE
fix: #942  Friend list closed on clicking anywhere

### DIFF
--- a/Client/src/components/stats/ProfileCard/ProfileCard.jsx
+++ b/Client/src/components/stats/ProfileCard/ProfileCard.jsx
@@ -236,18 +236,10 @@ const ProfileCard = ({ isCurrentUser = false }) => {
   }, [isCurrentUser, userId]);
 
   useEffect(() => {
-    if (showPopup) {
-      const handleClickOutside = (event) => {
-        if (popupRef.current && !popupRef.current.contains(event.target)) {
-          setShowPopup(false);
-        }
-      };
-
-      document.addEventListener("mousedown", handleClickOutside);
-      return () => {
-        document.removeEventListener("mousedown", handleClickOutside);
-      };
-    }
+    // Intentionally do NOT close the friends popup on outside clicks.
+    // Other popups in the app rely on the popup's own close button/backdrop
+    // behavior. Closing on any document click caused this popup to close
+    // immediately when users interact with other parts of the page.
   }, [showPopup]);
 
   if (isLoading || !user) return <ProfileSkeleton />;


### PR DESCRIPTION
## Description
This PR fixes the issue where the Friend List popup on the /stats page closes when clicking anywhere (including inside the card). The popup should only close when the Close button is explicitly clicked.

## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #942 

## Changes Made
-  Removed the global click-to-close logic for the Friend List popup.
-  Ensured the popup now closes only when the Close button is clicked.

## checklist

- [ ] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [ ] Only the necessary files are modified; no unrelated changes are included.
- [ ] Follows clean code principles (readable, maintainable, minimal duplication).
- [ ] All changes are clearly documented.
- [ ] Code has been tested across all supported themes and verified against potential edge cases.
- [ ] Multiple screenshots or recordings are attached (if required).
- [ ] No breaking changes are introduced to existing functionality.

