### PR TITLE
Enhanced note deletion with loading & undo

### DIFF
--- a/Client/src/components/notes/NoteCard.jsx
+++ b/Client/src/components/notes/NoteCard.jsx
@@ -6,6 +6,7 @@ import {
   Pin,
   Trash2,
   UserPlus,
+  Loader2,
 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -24,6 +25,7 @@ const NoteCard = ({
   setShowColorPicker,
   colors,
   getPlainTextPreview,
+  isDeleting,
 }) => {
   const [hovered, setHovered] = useState(false);
   const [showSharePopup, setShowSharePopup] = useState(false);
@@ -56,9 +58,8 @@ const NoteCard = ({
           onPin(note?._id, note?.pinnedAt);
         }}
         className={`absolute top-2 right-2 p-1 rounded-full bg-black/10 hover:bg-black/20 transition-opacity
-        ${
-          note?.pinnedAt ? "opacity-100" : hovered ? "opacity-100" : "opacity-0"
-        }`}
+        ${note?.pinnedAt ? "opacity-100" : hovered ? "opacity-100" : "opacity-0"
+          }`}
       >
         <Pin
           size={16}
@@ -146,8 +147,13 @@ const NoteCard = ({
             variant="transparent"
             size="icon"
             className="p-1 rounded hover:bg-[var(--bg-secondary)]"
+            disabled={isDeleting}
           >
-            <Trash2 size={16} />
+            {isDeleting ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Trash2 size={16} />
+            )}
           </Button>
         </motion.div>
       )}

--- a/Client/src/components/notes/NotesList.jsx
+++ b/Client/src/components/notes/NotesList.jsx
@@ -16,6 +16,7 @@ const NotesList = ({
   setShowColorPicker,
   colors,
   getPlainTextPreview,
+  deletingNoteId,
 }) => {
   const handleShareNote = async (noteId, userId, accessLevel) => {
     try {
@@ -36,8 +37,8 @@ const NotesList = ({
       if (error.response) {
         throw new Error(
           error.response.data?.error ||
-            error.response.data?.message ||
-            "Failed to share note"
+          error.response.data?.message ||
+          "Failed to share note"
         );
       } else {
         throw error;
@@ -77,6 +78,7 @@ const NotesList = ({
                 colors={colors}
                 getPlainTextPreview={getPlainTextPreview}
                 onShare={handleShareNote}
+                isDeleting={deletingNoteId === note?._id}
               />
             ))}
           </div>
@@ -115,6 +117,7 @@ const NotesList = ({
                 colors={colors}
                 getPlainTextPreview={getPlainTextPreview}
                 onShare={handleShareNote}
+                isDeleting={deletingNoteId === note?._id}
               />
             ))}
           </div>


### PR DESCRIPTION
Fixes #956 
Enhanced Note Deletion with Loading State and Undo Feature
Problem
When deleting notes, there was no visual feedback, and users couldn't undo accidental deletions.

Solution
✅ Added loading spinner to delete button (prevents double-clicks)
✅ Show toast notification: [Note "title..." is archived](vscode-file://vscode-app/c:/Users/hassan/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (truncates long titles)
✅ Added "Undo" button in toast to restore deleted notes