### PR TITLE
Fix: FIX the userProifile card

### DIFF
--- a/Client/src/components/stats/ProfileCard/ProfileHeader.jsx
+++ b/Client/src/components/stats/ProfileCard/ProfileHeader.jsx
@@ -20,12 +20,8 @@ const ProfileHeader = ({ user, profilelink, isCurrentUser }) => {
 
   return (
     <div className="flex items-center justify-between px-6 mb-4">
-      <div>
-        <h1 className="text-2xl font-semibold text-[var(--text-primary)]">
-          {user.FirstName} {user.LastName}
-        </h1>
-        <p className="text-[var(--text-secondary)] text-sm">@{user.Username}</p>
-      </div>
+      {/* spacer - main name/username is shown below the avatar, so remove the top duplicate */}
+      <div className="flex-1" />
 
       <div className="flex items-center gap-3">
         {isCurrentUser && (
@@ -37,11 +33,8 @@ const ProfileHeader = ({ user, profilelink, isCurrentUser }) => {
         {/* Dropdown for sharing profile link */}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button
-              variant="outline"
-              className="flex items-center space-x-2 text-sm"
-            >
-              <Share2 className="w-4 h-4" />
+            <Button variant="ghost" className="p-1 rounded-full">
+              <Share2 className="h-6 w-6 text-[var(--text-secondary)] hover:text-[var(--text-primary)]" />
             </Button>
           </DropdownMenuTrigger>
 


### PR DESCRIPTION
## Description
This PR fixes the user profile card UI:
- Removes the duplicate display of username and full name at the top of the card.
- Adjusts the size of the share button to match the edit button for consistent UI.
## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #961 

## Changes Made
<!-- List the changes made in this PR. -->
- [x]  Removed the redundant username and full name at the top of the card.
- [x]  Updated the share button styling to match the edit button size.
## Screenshots or GIFs (if applicable)
<img width="399" height="388" alt="image" src="https://github.com/user-attachments/assets/5d6d9e0b-1e6a-4722-a27f-a9cc2b75128f" />


## checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.

## Additional Notes
<!-- Add any other relevant information or context. -->
