### PR TITLE
Remove password field from login response (#973)

### DIFF
--- a/Server/Controller/AuthController.js
+++ b/Server/Controller/AuthController.js
@@ -178,10 +178,9 @@ const login = async (req, res) => {
     });
 
     // safe user for return response
-    const safeUser = await User.findOne(
-      {$or: [{ Email: identifier }, { Username: identifier }]},
-      {Password: 0}
-    );
+    const safeUser = await User.findOne({
+      $or: [{ Email: identifier }, { Username: identifier }]
+    }).select('-Password');
 
     return res.status(200).json({
       message: "User Login Successfully",


### PR DESCRIPTION
## Description
This PR fixes a security issue where the user's hashed password was being returned in the login API response.

## Related Issue
Fixes #973 

## Changes Made
Removed the Password field from the login response object.
Ensured only safe user data is sent.
Tested the endpoint using Postman & verified that password is no longer returned.

## Additional Notes
This fix improves security and prevents accidental password hash exposure in client responses.
