### PR TITLE
Fix: Adjust label spacing and reposition choices in "Education & Skills" section

### DIFF
--- a/Client/src/components/settings/EducationAndSkills.jsx
+++ b/Client/src/components/settings/EducationAndSkills.jsx
@@ -312,8 +312,8 @@ function EducationAndSkills() {
         </div>
 
         {/* Skills Section */}
-        <div className="px-6 py-2">
-          <div className="space-y-4">
+        <div className="px-6">
+          <div className={`space-y-2`}>
             <div className="flex items-center justify-between">
               <label
                 htmlFor="skills"
@@ -326,7 +326,7 @@ function EducationAndSkills() {
                   type="button"
                   onClick={() => handleClearOtherDetails("skills")}
                   variant="transparent"
-                  className="text-[var(--txt-dim)] hover:text-red-500 flex items-center gap-1 text-sm"
+                  className="text-[var(--txt-dim)] hover:text-red-500 items-center flex gap-1 text-sm"
                   disabled={isLoading}
                 >
                   <Trash2 className="w-4 h-4" />
@@ -335,28 +335,8 @@ function EducationAndSkills() {
               )}
             </div>
 
-            <div className="flex gap-2 flex-wrap">
-              {skillsList.map((skill, index) => (
-                <div
-                  key={index}
-                  className="flex items-center gap-2 bg-[var(--bg-sec)] px-3 py-2 rounded-lg"
-                >
-                  <span className="text-[var(--txt)] text-sm">{skill}</span>
-                  <Button
-                    type="button"
-                    onClick={() => removeSkill(skill)}
-                    variant="transparent"
-                    size="icon"
-                    className="text-[var(--txt-dim)] hover:text-red-500 p-1"
-                    disabled={isLoading}
-                  >
-                    <X className="w-4 h-4" />
-                  </Button>
-                </div>
-              ))}
-            </div>
-
-            <div className="flex gap-2">
+            <div className="space-y-4">
+              <div className="flex gap-2">
               <input
                 id="skills"
                 type="text"
@@ -383,12 +363,35 @@ function EducationAndSkills() {
                 Add
               </Button>
             </div>
+
+            <div className="flex gap-2 flex-wrap">
+              {skillsList.map((skill, index) => (
+                <div
+                  key={index}
+                  className="flex items-center gap-2 bg-[var(--bg-sec)] px-3 py-2 rounded-lg"
+                >
+                  <span className="text-[var(--txt)] text-sm">{skill}</span>
+                  <Button
+                    type="button"
+                    onClick={() => removeSkill(skill)}
+                    variant="transparent"
+                    size="icon"
+                    className="text-[var(--txt-dim)] hover:text-red-500 p-1"
+                    disabled={isLoading}
+                  >
+                    <X className="w-4 h-4" />
+                  </Button>
+                </div>
+              ))}
+            </div> 
+            </div>
+
           </div>
         </div>
 
         {/* Interests Section */}
-        <div className="px-6 py-2">
-          <div className="space-y-4">
+        <div className="px-6">
+          <div className="space-y-2">
             <div className="flex items-center justify-between">
               <label
                 htmlFor="interests"
@@ -410,28 +413,8 @@ function EducationAndSkills() {
               )}
             </div>
 
-            <div className="flex gap-2 flex-wrap">
-              {interestsList.map((interest, index) => (
-                <div
-                  key={index}
-                  className="flex items-center gap-2 bg-[var(--bg-sec)] px-3 py-2 rounded-lg"
-                >
-                  <span className="text-[var(--txt)] text-sm">{interest}</span>
-                  <Button
-                    type="button"
-                    onClick={() => removeInterest(interest)}
-                    variant="transparent"
-                    size="icon"
-                    className="text-[var(--txt-dim)] hover:text-red-500 p-1"
-                    disabled={isLoading}
-                  >
-                    <X className="w-4 h-4" />
-                  </Button>
-                </div>
-              ))}
-            </div>
-
-            <div className="flex gap-2">
+            <div className="space-y-4">
+              <div className="flex gap-2">
               <input
                 id="interests"
                 type="text"
@@ -458,6 +441,30 @@ function EducationAndSkills() {
                 Add
               </Button>
             </div>
+
+            <div className="flex gap-2 flex-wrap">
+              {interestsList.map((interest, index) => (
+                <div
+                  key={index}
+                  className="flex items-center gap-2 bg-[var(--bg-sec)] px-3 py-2 rounded-lg"
+                >
+                  <span className="text-[var(--txt)] text-sm">{interest}</span>
+                  <Button
+                    type="button"
+                    onClick={() => removeInterest(interest)}
+                    variant="transparent"
+                    size="icon"
+                    className="text-[var(--txt-dim)] hover:text-red-500 p-1"
+                    disabled={isLoading}
+                  >
+                    <X className="w-4 h-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+            
+            </div>
+
           </div>
         </div>
 

--- a/Server/package-lock.json
+++ b/Server/package-lock.json
@@ -79,6 +79,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1786,6 +1787,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",


### PR DESCRIPTION
### 🧾 Description
This PR fixes the UI layout issue where the **labels for “Skills” and “Interests”** were positioned too far from their respective input fields in the **Settings → Education & Skills** section.  
Additionally, it removes the **skills and interests choices (tags)** from between the label and input fields and places them **below the input fields** for better readability and structure.

### 🔖 Issue Reference
Closes: #963

## Changes Made
<!-- List the changes made in this PR. -->
- [x] Updated ...
- [x] Added ...

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->

### Before

<img width="1361" height="610" alt="error" src="https://github.com/user-attachments/assets/0342b6b6-dba9-4000-aa37-9b493bc3b74e" />

<img width="1366" height="727" alt="Screenshot 2025-10-15 215212" src="https://github.com/user-attachments/assets/d98e5ee4-b65d-4948-bb27-d32f474b075c" />


### After

<img width="1366" height="743" alt="Screenshot 2025-10-15 215324" src="https://github.com/user-attachments/assets/2e8c44c8-242e-4a5e-b2bb-019ed1ce73a2" />

<img width="1366" height="730" alt="Screenshot 2025-10-15 215553" src="https://github.com/user-attachments/assets/cbdea4c7-3cb0-4f34-8886-56771f6ee0a1" />



## checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.
