### PR TITLE
feat: add SessionRooms component and update RoomCard for joined room …

### DIFF
--- a/Client/src/components/session/RoomCard.jsx
+++ b/Client/src/components/session/RoomCard.jsx
@@ -18,7 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-export default function RoomCard({ room, onDelete, showCategory, loading, onRoomNotFound }) {
+export default function RoomCard({ room, onDelete, showCategory, loading, onRoomNotFound, isJoinedRoom = false }) {
   const [isPinned, setIsPinned] = useState(false);
   const [joinStatus, setJoinStatus] = useState(null); // 'member', 'pending', 'none'
   const navigate = useNavigate();
@@ -308,7 +308,15 @@ export default function RoomCard({ room, onDelete, showCategory, loading, onRoom
       {room.description && <p className="txt-dim mb-4">{room.description}</p>}
 
       {/* Join/Request Button Logic using joinStatus from backend */}
-      {room.isPrivate ? (
+      {isJoinedRoom ? (
+        <Button
+          onClick={handleJoin}
+          className="w-full flex items-center justify-center gap-2"
+        >
+          <Activity className="w-5 h-5" />
+          Enter Room
+        </Button>
+      ) : room.isPrivate ? (
         joinStatus === "member" ? (
           <Button
             onClick={handleJoin}

--- a/Client/src/components/session/SessionRooms.jsx
+++ b/Client/src/components/session/SessionRooms.jsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import RoomCard from "./RoomCard";
+
+export default function SessionRooms({ joinedRooms }) {
+  const [sessions, setSessions] = useState(joinedRooms);
+
+  useEffect(() => {
+    setSessions(joinedRooms.map((r) => ({ ...r, joins: r.joins ?? 0 })));
+  }, [joinedRooms]);
+
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl 2xl:text-2xl font-semibold txt">
+        Session Rooms
+      </h2>
+
+      {sessions.length === 0 ? (
+        <div
+          className="text-center p-8 rounded-3xl shadow-lg"
+          style={{
+            backgroundColor: "var(--bg-sec)",
+            color: "var(--txt-dim)",
+          }}
+        >
+          <p className="text-lg">
+            You haven't joined any rooms yet. Explore rooms to join them!
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <AnimatePresence>
+            {sessions.map((room) => (
+              <motion.div
+                key={room._id}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -20 }}
+                transition={{ duration: 0.3 }}
+              >
+                <RoomCard
+                  room={room}
+                  showCategory={true}
+                  isJoinedRoom={true}
+                />
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/Client/src/pages/Sessions.jsx
+++ b/Client/src/pages/Sessions.jsx
@@ -2,15 +2,17 @@ import { useEffect, useState } from "react";
 import OtherRoom from "../components/session/OtherRooms.jsx";
 import OnlineFriends from "../components/session/friendsSection/OnlineFriends.jsx";
 import YourRooms from "@/components/session/YourRooms.jsx";
+import SessionRooms from "@/components/session/SessionRooms.jsx";
 import NotLogedInPage from "@/components/NotLogedInPage.jsx";
 import axiosInstance from "@/utils/axios";
 import { useUserStore } from "@/stores/userStore.js";
 
 function Session() {
   const [view, setView] = useState("suggested");
-  const {user}=useUserStore();
+  const { user } = useUserStore();
   const [myRooms, setMyRooms] = useState([]);
   const [otherRooms, setOtherRooms] = useState([]);
+  const [joinedRooms, setJoinedRooms] = useState([]);
 
   useEffect(() => {
     const fetchRooms = async () => {
@@ -18,6 +20,7 @@ function Session() {
         const { data } = await axiosInstance.get("/session-room");
         setMyRooms(data.myRooms);
         setOtherRooms(data.otherRooms);
+        setJoinedRooms(data.joinedRooms || []);
       } catch (err) {
         console.error("Failed to fetch rooms:", err);
       }
@@ -32,6 +35,7 @@ function Session() {
     <div className="h-[100vh] w-[calc(100vw-70px)] pb-0 flex ">
       <div className="w-[80%] overflow-x-hidden p-3 2xl:p-6 space-y-6">
         <YourRooms myRooms={myRooms} />
+        <SessionRooms joinedRooms={joinedRooms} />
         <OtherRoom otherRooms={otherRooms} />
       </div>
       <aside className="w-[20%] overflow-scroll min-w-72 space-y-3 2xl:space-y-6 overflow-x-hidden p-3 2xl:p-6 border-l border-gray-500/20">

--- a/Server/Controller/SessionRoomController.js
+++ b/Server/Controller/SessionRoomController.js
@@ -25,6 +25,7 @@ import SessionRoom from "../Model/SessionModel.js";
 export const getRoomLists = async (req, res) => {
   try {
     const userId = req.user._id;
+    
     const rooms = await SessionRoom.find()
       .sort({ createdAt: -1 })
       .populate({
@@ -33,16 +34,25 @@ export const getRoomLists = async (req, res) => {
       })
       .lean();
 
+
     const myRooms = [];
     const otherRooms = [];
+    const joinedRooms = [];
+    
     for (const r of rooms) {
-      (r.createdBy.toString() === userId.toString()
-        ? myRooms
-        : otherRooms
-      ).push(r);
+      const isCreator = r.createdBy.toString() === userId.toString();
+      const isMember = r.members.some(memberId => memberId.toString() === userId.toString());
+      
+      if (isCreator) {
+        myRooms.push(r);
+      } else if (isMember) {
+        joinedRooms.push(r);
+      } else {
+        otherRooms.push(r);
+      }
     }
 
-    return res.json({ myRooms, otherRooms });
+    return res.json({ myRooms, otherRooms, joinedRooms });
   } catch (err) {
     return res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Description
Added a new "Session Rooms" section to display rooms that the user has joined (but didn't create). This section appears below "Your Rooms" and above "Explore Rooms" to provide better organization of room access. Also implemented proper join functionality for public rooms where users become members upon joining.

## Related Issue
Fixes [#998](https://github.com/EduHaven/EduHaven/issues/998)

## Changes Made
- [x] Added new `SessionRooms` component for displaying joined rooms
- [x] Updated backend API (`getRoomLists`) to return `joinedRooms` array
- [x] Modified `Sessions.jsx` to include the new Session Rooms section
- [x] Enhanced `RoomCard` component with `isJoinedRoom` prop for proper button display
- [x] Implemented join functionality for public rooms (users become members)
- [x] Removed delete option from joined rooms (only creators can delete)
- [x] All buttons in Session Rooms show "Enter Room" with activity icon
- [x] Added proper room categorization (created by user vs joined vs others)

## Screenshots or GIFs (if applicable)
<img width="1079" height="993" alt="image" src="https://github.com/user-attachments/assets/2f36169b-b448-4eed-a057-027b1657effe" />

## Checklist
- [x] Code is formatted with the project's Prettier config provided in `.prettierrc`
- [x] Only the necessary files are modified; no unrelated changes are included
- [x] Follows clean code principles (readable, maintainable, minimal duplication)
- [x] All changes are clearly documented
- [x] Code has been tested across all supported themes and verified against potential edge cases
- [x] Multiple screenshots or recordings are attached (if required)
- [x] No breaking changes are introduced to existing functionality

## Additional Notes
- The Session Rooms section only displays rooms where the user is a member but not the creator
- Public room join functionality now properly adds users to the room's members array
- Delete functionality is appropriately restricted to room creators only
- All room cards maintain consistent UI/UX with proper button states
- Backend API now returns three categories: `myRooms`, `joinedRooms`, and `otherRooms`