### PR TITLE
Display collaborators tiny profiles

### DIFF
--- a/Client/src/components/notes/NoteFooter.jsx
+++ b/Client/src/components/notes/NoteFooter.jsx
@@ -16,8 +16,10 @@ const getCurrentUserId = () => {
 
 const NoteFooter = ({ note }) => {
   const [owner, setOwner] = useState(null);
+  const [collaboratorsData, setCollaboratorsData] = useState([]);
   const currentUserId = getCurrentUserId();
 
+  // fetch real owner
   useEffect(() => {
     const getUser = async () => {
       const data = await fetchUserDetails(note?.owner);
@@ -26,7 +28,28 @@ const NoteFooter = ({ note }) => {
     getUser();
   }, [note?.owner]);
 
+  // fetch collaborators details
+  useEffect(() => {
+    const getCollaborators = async () => {
+      if (note?.collaborators?.length) {
+        const data = await Promise.all(
+          note.collaborators.map(async (collab) => {
+            const res = await fetchUserDetails(collab.user._id);
+            return res;
+          })
+        );
+        setCollaboratorsData(data);
+      }
+    };
+    getCollaborators();
+  }, [note?.collaborators]);
+
   const isOwner = note.owner === currentUserId;
+
+  // limit displaying collaborators profile (default: 5)
+  const visibleCollaborators = collaboratorsData.slice(0, 5);
+  // remaining collaborators count
+  const extraCount = collaboratorsData.length - 5;
 
   // visibility
   let visibility = "Private";
@@ -35,22 +58,37 @@ const NoteFooter = ({ note }) => {
     visibility = "Shared";
 
   return (
-    <div
-      className="text-xs mt-2 flex justify-between items-center"
-      style={{ color: "var(--txt-disabled)" }}
-    >
-      {new Date(note?.createdAt).toLocaleDateString()}
-      <div className="border px-1 h-7 rounded-full flex items-center justify-center">
-        <span className="mx-1">{visibility}</span>
-        {visibility === "Shared" && !isOwner && owner?.ProfilePicture && (
-          <img
-            className="w-5 h-5 rounded-full"
-            src={owner?.ProfilePicture}
-            alt={owner?.FirstName}
-          />
-        )}
+    <>
+      {visibility === "Shared" && isOwner && note?.collaborators.length && (
+        <div className="flex items-center space-x-2 w-full">
+          {visibleCollaborators.map((collab) => (
+            <img
+              key={collab._id}
+              className="w-5 h-5 rounded-full"
+              src={collab?.ProfilePicture}
+              alt={collab?.FirstName}
+            />
+          ))}
+          {extraCount > 0 && <span className="text-xs">+{extraCount}</span>}
+        </div>
+      )}
+      <div
+        className="text-xs flex justify-between items-center"
+        style={{ color: "var(--txt-disabled)" }}
+      >
+        {new Date(note?.createdAt).toLocaleDateString()}
+        <div className="border px-1 h-7 rounded-full flex items-center justify-center">
+          <span className="mx-1">{visibility}</span>
+          {visibility === "Shared" && !isOwner && owner?.ProfilePicture && (
+            <img
+              className="w-5 h-5 rounded-full"
+              src={owner?.ProfilePicture}
+              alt={owner?.FirstName}
+            />
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/Client/src/components/notes/NoteFooter.jsx
+++ b/Client/src/components/notes/NoteFooter.jsx
@@ -1,5 +1,5 @@
-import { fetchUserDetails } from "@/api/userApi";
-import { useEffect, useState } from "react";
+import { useNoteStore } from "@/stores/useNoteStore";
+import { useEffect } from "react";
 
 const getCurrentUserId = () => {
   const token = localStorage.getItem("token");
@@ -15,41 +15,19 @@ const getCurrentUserId = () => {
 };
 
 const NoteFooter = ({ note }) => {
-  const [owner, setOwner] = useState(null);
-  const [collaboratorsData, setCollaboratorsData] = useState([]);
   const currentUserId = getCurrentUserId();
+  const { owners, collaborators, setOwner, setCollaborators } = useNoteStore();
 
   // fetch real owner
   useEffect(() => {
-    const getUser = async () => {
-      const data = await fetchUserDetails(note?.owner);
-      setOwner(data);
-    };
-    getUser();
-  }, [note?.owner]);
+    if (note?.owner && !owners[note.owner]) setOwner(note.owner);
+    if (note?.collaborators?.length && !collaborators[note._id])
+      setCollaborators(note);
+  }, [note, owners, collaborators, setOwner, setCollaborators]);
 
-  // fetch collaborators details
-  useEffect(() => {
-    const getCollaborators = async () => {
-      if (note?.collaborators?.length) {
-        const data = await Promise.all(
-          note.collaborators.map(async (collab) => {
-            const res = await fetchUserDetails(collab.user._id);
-            return res;
-          })
-        );
-        setCollaboratorsData(data);
-      }
-    };
-    getCollaborators();
-  }, [note?.collaborators]);
-
+  const owner = owners[note.owner];
+  const collabs = collaborators[note._id] || [];
   const isOwner = note.owner === currentUserId;
-
-  // limit displaying collaborators profile (default: 5)
-  const visibleCollaborators = collaboratorsData.slice(0, 5);
-  // remaining collaborators count
-  const extraCount = collaboratorsData.length - 5;
 
   // visibility
   let visibility = "Private";
@@ -57,16 +35,19 @@ const NoteFooter = ({ note }) => {
   else if (note.visibility === "private" && note.collaborators?.length)
     visibility = "Shared";
 
+  const visibleCollabs = collabs.slice(0, 5);
+  const extraCount = collabs.length - 5;
+
   return (
     <>
-      {visibility === "Shared" && isOwner && note?.collaborators.length && (
+      {visibility === "Shared" && isOwner && (
         <div className="flex items-center space-x-2 w-full">
-          {visibleCollaborators.map((collab) => (
+          {visibleCollabs.map((c) => (
             <img
-              key={collab._id}
+              key={c._id}
               className="w-5 h-5 rounded-full"
-              src={collab?.ProfilePicture}
-              alt={collab?.FirstName}
+              src={c?.ProfilePicture}
+              alt={c?.FirstName}
             />
           ))}
           {extraCount > 0 && <span className="text-xs">+{extraCount}</span>}

--- a/Client/src/components/notes/NoteFooter.jsx
+++ b/Client/src/components/notes/NoteFooter.jsx
@@ -42,7 +42,7 @@ const NoteFooter = ({ note }) => {
       }
     };
     getCollaborators();
-  }, [note?.collaborators]);
+  }, [note?.collaborators?.length]);
 
   const isOwner = note.owner === currentUserId;
 
@@ -60,7 +60,7 @@ const NoteFooter = ({ note }) => {
   return (
     <>
       {visibility === "Shared" && isOwner && note?.collaborators.length && (
-        <div className="flex items-center space-x-2 w-full">
+        <div className="flex items-center space-x-1 w-full">
           {visibleCollaborators.map((collab) => (
             <img
               key={collab._id}

--- a/Client/src/stores/useNoteStore.js
+++ b/Client/src/stores/useNoteStore.js
@@ -1,18 +1,39 @@
-import { create } from 'zustand';
+import { fetchUserDetails } from "@/api/userApi";
+import { create } from "zustand";
 
 export const useNoteStore = create((set, get) => ({
   // State
-  status: 'active', // active, archive, trash
-  searchTerm: '',
+  status: "active", // active, archive, trash
+  searchTerm: "",
   selectedNote: null,
   showColorPicker: null,
-  
+  owners: {},
+  collaborators: {},
+
   // Actions
   setStatus: (status) => set({ status }),
   setSearchTerm: (searchTerm) => set({ searchTerm }),
   setSelectedNote: (selectedNote) => set({ selectedNote }),
   setShowColorPicker: (showColorPicker) => set({ showColorPicker }),
-  
+
+  setOwner: async (userId) => {
+    const data = await fetchUserDetails(userId);
+    set((state) => ({ owners: { ...state.owners, [userId]: data } }));
+  },
+
+  setCollaborators: async (note) => {
+    if (!note?.collaborators?.length) return;
+    const data = await Promise.all(
+      note.collaborators.map(async (collab) => {
+        const res = await fetchUserDetails(collab.user._id);
+        return res;
+      })
+    );
+    set((state) => ({
+      collaborators: { ...state.collaborators, [note._id]: data },
+    }));
+  },
+
   // Note actions
   updateNote: (id, updates) => {
     const { selectedNote } = get();
@@ -21,7 +42,7 @@ export const useNoteStore = create((set, get) => ({
     }
     return { id, updates };
   },
-  
+
   togglePin: (id, pinnedAt) => {
     const { selectedNote } = get();
     if (selectedNote && selectedNote._id === id) {
@@ -29,7 +50,7 @@ export const useNoteStore = create((set, get) => ({
     }
     return { id, updates: { pinnedAt: !pinnedAt } };
   },
-  
+
   changeColor: (id, color) => {
     const { selectedNote } = get();
     if (selectedNote && selectedNote._id === id) {

--- a/Client/src/stores/useNoteStore.js
+++ b/Client/src/stores/useNoteStore.js
@@ -1,39 +1,18 @@
-import { fetchUserDetails } from "@/api/userApi";
-import { create } from "zustand";
+import { create } from 'zustand';
 
 export const useNoteStore = create((set, get) => ({
   // State
-  status: "active", // active, archive, trash
-  searchTerm: "",
+  status: 'active', // active, archive, trash
+  searchTerm: '',
   selectedNote: null,
   showColorPicker: null,
-  owners: {},
-  collaborators: {},
-
+  
   // Actions
   setStatus: (status) => set({ status }),
   setSearchTerm: (searchTerm) => set({ searchTerm }),
   setSelectedNote: (selectedNote) => set({ selectedNote }),
   setShowColorPicker: (showColorPicker) => set({ showColorPicker }),
-
-  setOwner: async (userId) => {
-    const data = await fetchUserDetails(userId);
-    set((state) => ({ owners: { ...state.owners, [userId]: data } }));
-  },
-
-  setCollaborators: async (note) => {
-    if (!note?.collaborators?.length) return;
-    const data = await Promise.all(
-      note.collaborators.map(async (collab) => {
-        const res = await fetchUserDetails(collab.user._id);
-        return res;
-      })
-    );
-    set((state) => ({
-      collaborators: { ...state.collaborators, [note._id]: data },
-    }));
-  },
-
+  
   // Note actions
   updateNote: (id, updates) => {
     const { selectedNote } = get();
@@ -42,7 +21,7 @@ export const useNoteStore = create((set, get) => ({
     }
     return { id, updates };
   },
-
+  
   togglePin: (id, pinnedAt) => {
     const { selectedNote } = get();
     if (selectedNote && selectedNote._id === id) {
@@ -50,7 +29,7 @@ export const useNoteStore = create((set, get) => ({
     }
     return { id, updates: { pinnedAt: !pinnedAt } };
   },
-
+  
   changeColor: (id, color) => {
     const { selectedNote } = get();
     if (selectedNote && selectedNote._id === id) {


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what this PR does. -->
To display group of collaborators, added initial logic where introduced a new react state `collaboratorsData` and fetching each collaborators details then display first 5 collaborator profile image.

## Related Issue
<!-- If this PR addresses an issue, please include the issue number. -->
Fixes #1016 

## Changes Made
<!-- List the changes made in this PR. -->
- [x] Updated `NoteFooter.jsx`
- [ ] Added ...

## Screenshots or GIFs (if applicable)
<!-- Add visual changes to better communicate your changes. -->
<img width="221" height="161" alt="Screenshot 2025-10-23 194833" src="https://github.com/user-attachments/assets/dc6bd366-ccdc-4f96-93ec-90be7b1db287" />
<img width="222" height="149" alt="Screenshot 2025-10-23 194858" src="https://github.com/user-attachments/assets/1ef12449-c6c3-453e-8010-87535ee9cc7b" />


## checklist

- [x] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.
