### PR TITLE
Enhance: UI of Room Requests

### DIFF
--- a/Client/src/components/session/PendingRequestsSection.jsx
+++ b/Client/src/components/session/PendingRequestsSection.jsx
@@ -1,0 +1,169 @@
+import { Button as UIButton } from "@/components/ui/button";
+import { useNavigate } from "react-router-dom";
+import axiosInstance from "@/utils/axios";
+
+export default function PendingRequestsSection({ myRooms, onRequestHandled }) {
+  const navigate = useNavigate();
+
+  const OpenProfile = (user) => {
+    if (user._id) {
+      navigate(`/user/${user._id}`, { replace: true });
+    }
+  };
+
+  const handleRequest = async (roomId, targetUserId, action) => {
+    try {
+      await axiosInstance.post(`/session-room/${roomId}/handle-request`, {
+        targetUserId,
+        action,
+      });
+
+      // Notify parent to update roomd
+      if (onRequestHandled) {
+        onRequestHandled(roomId, targetUserId, action);
+      }
+    } catch (err) {
+      alert(err.response?.data?.error || "Failed to handle request");
+    }
+  };
+
+  // Filter rooms with pending requests
+  const roomsWithRequests = myRooms.filter(
+    (room) =>
+      room.isPrivate && room.pendingRequests && room.pendingRequests.length > 0
+  );
+
+  if (roomsWithRequests.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-lg font-semibold txt">Pending Join Requests</h2>
+
+      {roomsWithRequests.map((room) => (
+        <div
+          key={room._id}
+          className="rounded-xl border border-[var(--bg-ter)] bg-[var(--bg-secondary)] p-3 space-y-3"
+        >
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-sm txt truncate">{room.name}</h3>
+            <span className="text-xs text-[var(--txt-dim)] bg-[var(--bg-ter)] px-2 py-1 rounded-full">
+              {room.pendingRequests.length}{" "}
+              {room.pendingRequests.length === 1 ? "request" : "requests"}
+            </span>
+          </div>
+
+          <div className="space-y-2">
+            {room.pendingRequests.map((user) => (
+              <div
+                key={user._id}
+                className="rounded-lg border border-[var(--bg-ter)] bg-[var(--bg-primary)] p-2.5 space-y-2"
+              >
+                <div
+                  onClick={() => OpenProfile(user)}
+                  className="flex items-start gap-2.5 cursor-pointer"
+                >
+                  <img
+                    src={
+                      user.ProfilePicture ||
+                      "https://api.dicebear.com/9.x/initials/svg?seed=" +
+                        user.Username
+                    }
+                    alt={user.Username}
+                    className="w-10 h-10 rounded-full object-cover flex-shrink-0"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <span className="font-medium txt block text-sm">
+                      {user.Username}
+                    </span>
+                    <p className="text-xs text-[var(--txt-dim)] line-clamp-2 mt-0.5">
+                      {user.Bio || "No bio provided"}
+                    </p>
+                  </div>
+                </div>
+
+                {user.OtherDetails?.skills && (
+                  <div>
+                    <p className="text-xs font-medium text-[var(--txt-dim)] mb-1.5">
+                      Skills
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {user.OtherDetails.skills
+                        .split(",")
+                        .slice(0, 3)
+                        .map((s, i) => (
+                          <span
+                            key={`skill-${i}`}
+                            className="inline-flex items-center px-2 py-0.5 bg-amber-900/40 text-amber-300 text-[10px] rounded-full whitespace-nowrap border border-amber-700/30"
+                          >
+                            {s.trim()}
+                          </span>
+                        ))}
+                      {user.OtherDetails.skills.split(",").length > 3 && (
+                        <span className="text-[var(--txt-disabled)] text-[10px] px-2 py-0.5">
+                          +{user.OtherDetails.skills.split(",").length - 3} more
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {user.OtherDetails?.interests && (
+                  <div>
+                    <p className="text-xs font-medium text-[var(--txt-dim)] mb-1.5">
+                      Interests
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {user.OtherDetails.interests
+                        .split(",")
+                        .slice(0, 3)
+                        .map((i, idx) => (
+                          <span
+                            key={`interest-${idx}`}
+                            className="inline-flex items-center px-2 py-0.5 bg-cyan-900/40 text-cyan-300 text-[10px] rounded-full whitespace-nowrap border border-cyan-700/30"
+                          >
+                            {i.trim()}
+                          </span>
+                        ))}
+                      {user.OtherDetails.interests.split(",").length > 3 && (
+                        <span className="text-[var(--txt-disabled)] text-[10px] px-2 py-0.5">
+                          +{user.OtherDetails.interests.split(",").length - 3}{" "}
+                          more
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex gap-2 w-full pt-1">
+                  <UIButton
+                    size="sm"
+                    className="bg-green-600 hover:bg-green-700 text-white flex-1 h-8 text-xs"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRequest(room._id, user._id, "approve");
+                    }}
+                  >
+                    Approve
+                  </UIButton>
+                  <UIButton
+                    size="sm"
+                    variant="destructive"
+                    className="flex-1 h-8 text-xs"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRequest(room._id, user._id, "reject");
+                    }}
+                  >
+                    Reject
+                  </UIButton>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/Client/src/components/session/YourRooms.jsx
+++ b/Client/src/components/session/YourRooms.jsx
@@ -1,19 +1,16 @@
 import { useEffect, useState } from "react";
-import { Button as UIButton } from "@/components/ui/button";
 import { PlusCircle } from "lucide-react";
 import axiosInstance from "@/utils/axios";
 import { motion, AnimatePresence } from "framer-motion";
 import RoomCard from "./RoomCard";
 import CreateRoomModal from "./CreateRoomModal";
 import { Button } from "@/components/ui/button";
-import { useNavigate } from "react-router-dom";
 
 export default function YourRooms({ myRooms }) {
   const [sessions, setSessions] = useState(myRooms);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [roomToDelete, setRoomToDelete] = useState(null);
-  const navigate = useNavigate();
 
   useEffect(() => {
     setSessions(myRooms.map((r) => ({ ...r, joins: r.joins ?? 0 })));
@@ -50,40 +47,6 @@ export default function YourRooms({ myRooms }) {
     setRoomToDelete(null);
   };
 
-  const OpenProfile = (user) => {
-    if (user._id) {
-      navigate(`/user/${user._id}`, { replace: true });
-    }
-  };
-
-  const handleRequest = async (roomId, targetUserId, action) => {
-    try {
-      await axiosInstance.post(`/session-room/${roomId}/handle-request`, {
-        targetUserId,
-        action,
-      });
-
-      setSessions((prev) =>
-        prev.map((room) =>
-          room._id === roomId
-            ? {
-                ...room,
-                pendingRequests: room.pendingRequests.filter(
-                  (user) => user._id !== targetUserId
-                ),
-                members:
-                  action === "approve"
-                    ? [...room.members, targetUserId]
-                    : room.members,
-              }
-            : room
-        )
-      );
-    } catch (err) {
-      alert(err.response?.data?.error || "Failed to handle request");
-    }
-  };
-
   return (
     <div className="flex-1">
       <h1 className="text-lg 2xl:text-2xl font-semibold txt mb-3 2xl:mb-6">
@@ -92,136 +55,12 @@ export default function YourRooms({ myRooms }) {
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 2xl:gap-6">
         {sessions.map((room) => (
-          <div key={room._id}>
-            <RoomCard
-              room={room}
-              onDelete={() => handleDeleteClick(room)}
-              showCategory={true}
-            />
-            {room.isPrivate &&
-              room.pendingRequests &&
-              room.pendingRequests.length > 0 && (
-                <div className="bg-gray-800/40 border border-gray-700/50 rounded-xl p-3 mt-2 space-y-2">
-                  <div className="font-semibold txt text-sm">
-                    Pending Join Requests ({room.pendingRequests.length}):
-                  </div>
-
-                  {room.pendingRequests.map((user) => (
-                    <div
-                      key={user._id}
-                      onClick={() => OpenProfile(user)}
-                      className="flex flex-col cursor-pointer gap-2 p-2.5 bg-gray-700/50 rounded-lg"
-                    >
-                      <div className="flex flex-col items-start gap-2.5">
-                        <div className="flex justify-between items-center gap-2">
-                          <img
-                            src={
-                              user.ProfilePicture ||
-                              "https://ui-avatars.com/api/?name=" +
-                                user.Username
-                            }
-                            alt={user.Username}
-                            className="w-10 h-10 rounded-full object-cover flex-shrink-0"
-                          />
-                          <div className="flex-1 min-w-0">
-                            <span className="font-medium text-white block text-sm">
-                              {user.Username}
-                            </span>
-                            <p className="text-xs text-gray-400 line-clamp-2 mt-0.5">
-                              {user.Bio || "No bio provided"}
-                            </p>
-                          </div>
-                        </div>
-
-                        {user.OtherDetails?.skills && (
-                          <div className="mb-2">
-                            <p className="text-xs font-medium text-gray-300 mb-1.5">
-                              Skills
-                            </p>
-                            <div className="flex flex-wrap gap-1.5">
-                              {user.OtherDetails.skills
-                                .split(",")
-                                .slice(0, 3)
-                                .map((s, i) => (
-                                  <span
-                                    key={`skill-${i}`}
-                                    className="inline-flex items-center px-2.5 py-1 bg-amber-900/40 text-amber-300 text-[10px] sm:text-xs rounded-full whitespace-nowrap border border-amber-700/30 hover:bg-amber-900/60 transition-colors"
-                                  >
-                                    {s.trim()}
-                                  </span>
-                                ))}
-                              {user.OtherDetails.skills.split(",").length >
-                                3 && (
-                                <span className="text-gray-500 text-[10px] sm:text-xs px-2 py-1">
-                                  +
-                                  {user.OtherDetails.skills.split(",").length -
-                                    3}{" "}
-                                  more
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                        )}
-
-                        {user.OtherDetails?.interests && (
-                          <div className="mb-4">
-                            <p className="text-xs font-medium text-gray-300 mb-1.5">
-                              Interests
-                            </p>
-                            <div className="flex flex-wrap gap-1.5">
-                              {user.OtherDetails.interests
-                                .split(",")
-                                .slice(0, 3)
-                                .map((i, idx) => (
-                                  <span
-                                    key={`interest-${idx}`}
-                                    className="inline-flex items-center px-2.5 py-1 bg-cyan-900/40 text-cyan-300 text-[10px] sm:text-xs rounded-full whitespace-nowrap border border-cyan-700/30 hover:bg-cyan-900/60 transition-colors"
-                                  >
-                                    {i.trim()}
-                                  </span>
-                                ))}
-                              {user.OtherDetails.interests.split(",").length >
-                                3 && (
-                                <span className="text-gray-500 text-[10px] sm:text-xs px-2 py-1">
-                                  +
-                                  {user.OtherDetails.interests.split(",")
-                                    .length - 3}{" "}
-                                  more
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-
-                      <div className="flex gap-2 w-full">
-                        <UIButton
-                          size="sm"
-                          className="bg-green-600 hover:bg-green-700 text-white flex-1 h-9 text-sm"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleRequest(room._id, user._id, "approve")
-                          }}
-                        >
-                          Approve
-                        </UIButton>
-                        <UIButton
-                          size="sm"
-                          variant="destructive"
-                          className="flex-1 h-9 text-sm"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleRequest(room._id, user._id, "reject")
-                          }}
-                        >
-                          Reject
-                        </UIButton>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-          </div>
+          <RoomCard
+            key={room._id}
+            room={room}
+            onDelete={() => handleDeleteClick(room)}
+            showCategory={true}
+          />
         ))}
 
         <Button

--- a/Client/src/pages/Sessions.jsx
+++ b/Client/src/pages/Sessions.jsx
@@ -15,7 +15,9 @@ function Session() {
   const [joinedRooms, setJoinedRooms] = useState([]);
 
   const handleRoomLeft = (roomId) => {
-    setJoinedRooms(prevRooms => prevRooms.filter(room => room._id !== roomId));
+    setJoinedRooms((prevRooms) =>
+      prevRooms.filter((room) => room._id !== roomId)
+    );
   };
 
   const handleRequestHandled = (roomId, targetUserId, action) => {
@@ -62,11 +64,11 @@ function Session() {
         <OtherRoom otherRooms={otherRooms} />
       </div>
       <aside className="w-[20%] overflow-scroll min-w-72 space-y-3 2xl:space-y-6 overflow-x-hidden p-3 2xl:p-6 border-l border-[var(--bg-ter)]">
+        <OnlineFriends />
         <PendingRequestsSection
           myRooms={myRooms}
           onRequestHandled={handleRequestHandled}
         />
-        <OnlineFriends />
       </aside>
     </div>
   );

--- a/Client/src/pages/Sessions.jsx
+++ b/Client/src/pages/Sessions.jsx
@@ -4,11 +4,11 @@ import OnlineFriends from "../components/session/friendsSection/OnlineFriends.js
 import YourRooms from "@/components/session/YourRooms.jsx";
 import SessionRooms from "@/components/session/SessionRooms.jsx";
 import NotLogedInPage from "@/components/NotLogedInPage.jsx";
+import PendingRequestsSection from "@/components/session/PendingRequestsSection.jsx";
 import axiosInstance from "@/utils/axios";
 import { useUserStore } from "@/stores/userStore.js";
 
 function Session() {
-  const [view, setView] = useState("suggested");
   const { user } = useUserStore();
   const [myRooms, setMyRooms] = useState([]);
   const [otherRooms, setOtherRooms] = useState([]);
@@ -16,6 +16,25 @@ function Session() {
 
   const handleRoomLeft = (roomId) => {
     setJoinedRooms(prevRooms => prevRooms.filter(room => room._id !== roomId));
+  };
+
+  const handleRequestHandled = (roomId, targetUserId, action) => {
+    setMyRooms((prev) =>
+      prev.map((room) =>
+        room._id === roomId
+          ? {
+              ...room,
+              pendingRequests: room.pendingRequests.filter(
+                (user) => user._id !== targetUserId
+              ),
+              members:
+                action === "approve"
+                  ? [...room.members, targetUserId]
+                  : room.members,
+            }
+          : room
+      )
+    );
   };
 
   useEffect(() => {
@@ -42,7 +61,11 @@ function Session() {
         <SessionRooms joinedRooms={joinedRooms} onRoomLeft={handleRoomLeft} />
         <OtherRoom otherRooms={otherRooms} />
       </div>
-      <aside className="w-[20%] overflow-scroll min-w-72 space-y-3 2xl:space-y-6 overflow-x-hidden p-3 2xl:p-6 border-l border-gray-500/20">
+      <aside className="w-[20%] overflow-scroll min-w-72 space-y-3 2xl:space-y-6 overflow-x-hidden p-3 2xl:p-6 border-l border-[var(--bg-ter)]">
+        <PendingRequestsSection
+          myRooms={myRooms}
+          onRequestHandled={handleRequestHandled}
+        />
         <OnlineFriends />
       </aside>
     </div>


### PR DESCRIPTION
## Description
Reorganized the pending room join requests UI by moving them from inline displays below each room card to a dedicated section in the right sidebar. Requests are now grouped by room, making it easier to manage and providing a cleaner, more organized interface.

## Related Issue
Fixes #995 

## Changes Made
- [x] Created `PendingRequestsSection` component to display all pending join requests grouped by room
- [x] Added the new component to the right sidebar in Sessions page above OnlineFriends
- [x] Removed inline pending request displays from below individual room cards in YourRooms
- [x] Cleaned up unused imports and code from YourRooms.

## Screenshots or GIFs (if applicable)
###Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2cd5e88a-12fd-404c-848e-bf896adc1711" />

###After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/662cbc8c-82ad-41bf-8730-39229aff630c" />


## checklist

- [ ] Code is formatted with the project’s Prettier config provided in `.prettierrc`.
- [x] Only the necessary files are modified; no unrelated changes are included.
- [x] Follows clean code principles (readable, maintainable, minimal duplication).
- [x] All changes are clearly documented.
- [x] Code has been tested across all supported themes and verified against potential edge cases.
- [x] Multiple screenshots or recordings are attached (if required).
- [x] No breaking changes are introduced to existing functionality.

## Additional Notes
- The new PendingRequestsSection.jsx component is reusable and can be easily modified or extended